### PR TITLE
Compartment Transition

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,47 @@
+# CHERI ELF compartmentalisation
+
+An approach to provide compartmentalisation to user-code in a hybrid CHERI
+environment.
+
+### Overview
+
+The idea is to provide a library with an API to allow user-code to be
+compartmentalized with respect to data. This means that when we enter a
+compartment, we expect to not be able to read or write from memory that is not
+associated with that compartment. This is achieved via the default data
+capability (`DDC`) register.
+
+Eventual desired functionality:
+* load a binary, identifying appropriate entry points
+* execute a loaded binary, given a previously identified valid entry point
+* inter-compartment communication, either via capabilities, or shared memory
+
+#### Executing a compartment
+
+TODO
+* transitioning into a compartment, ensuring no data is leaked, and state is
+  consistent;
+* inter-compartment communication;
+* transitioning out of a compartment, returning some required result.
+
+#### Function interception
+
+Not all functions within a compartment can be executed with a restrained `DDC`.
+For example, `vDSO` functions would not have access to the `vDSO` page
+dynamically loaded against the manager, and memory management functions are not
+aware of the limited space allocated to a compartment for scratch memory. As
+such, we *intercept* these functions, in order to execute them with higher
+privilege (i.e., unbound `DDC`), and in a controlled fashion. This involves
+patching each intercepted function with code to perform a transition into the
+manager (at the same time unbounding the `DDC`), performing the associated
+function, then transitioning back into the compartment.
+
+#### Limitations (and sort-of main TODO list)
+
+Current limitations (as this is a work in progress, some of these are planned
+to be addressed):
+* single compartment;
+* the user-code must be compiled with `--static` and `--image-base` set to some
+  pre-determined variable;
+* entry point of the compartment is via `main`, and no parameters are
+  supported.

--- a/include/compartment.h
+++ b/include/compartment.h
@@ -29,11 +29,19 @@
 // about
 
 struct func_intercept;
+void compartment_transition_out();
+int64_t comp_exec_in(void*, void* __capability, void*);
+void comp_exec_out();
+
+#define INTERCEPT_INSTR_COUNT 5
+#define COMP_TRANS_FN_INSTR_CNT 4
 
 struct intercept_patch
 {
     int* patch_addr;
-    uint32_t instr;
+    int32_t instr[INTERCEPT_INSTR_COUNT];
+    uintptr_t comp_manager_cap_addr;
+    void* __capability manager_cap;
 };
 
 /* Struct representing one segment of an ELF binary.
@@ -79,10 +87,19 @@ struct Compartment
     uintptr_t scratch_mem_base;
     size_t scratch_mem_size;
     size_t scratch_mem_alloc;
+
+    size_t scratch_mem_heap_size;
     uintptr_t scratch_mem_stack_top;
     size_t scratch_mem_stack_size;
     uintptr_t stack_pointer;
     struct mem_alloc* alloc_head;
+
+    uintptr_t manager_caps;
+    size_t max_manager_caps_count;
+    size_t active_manager_caps_count;
+
+    uintptr_t mng_trans_fn;
+    size_t mng_trans_fn_sz;
     // Hardware info - maybe move
     size_t page_size;
     // Misc

--- a/include/compartment.h
+++ b/include/compartment.h
@@ -33,9 +33,20 @@ void compartment_transition_out();
 int64_t comp_exec_in(void*, void* __capability, void*);
 void comp_exec_out();
 
+// Declare built-in function for cache synchronization:
+// https://community.arm.com/arm-community-blogs/b/architectures-and-processors-blog/posts/caches-and-self-modifying-code
+extern void __clear_cache(void*, void*);
+
+// Number of instructions to inject at intercepted function call point
+// TODO ensure there is sufficient space for these, so we don't spill over
 #define INTERCEPT_INSTR_COUNT 5
+
+// Number of instructions required by the transition function
 #define COMP_TRANS_FN_INSTR_CNT 4
 
+/* For a function to be intercepted, information required to insert the
+ * redirect code and perform redirection
+ */
 struct intercept_patch
 {
     int* patch_addr;
@@ -58,6 +69,9 @@ struct SegmentMap
     int prot_flags;
 };
 
+/* Struct representing ELF data necessary to load and eventually execute a
+ * compartment
+ */
 struct Compartment
 {
     // Identifiers
@@ -104,8 +118,7 @@ struct Compartment
     size_t page_size;
     // Misc
     short curr_intercept_count;
-    struct intercept_patch patches[MAX_INTERCEPT_COUNT];
-
+    struct intercept_patch patches[INTERCEPT_FUNC_COUNT];
 };
 
 extern struct Compartment** comps;

--- a/include/manager.h
+++ b/include/manager.h
@@ -15,12 +15,14 @@
  ******************************************************************************/
 
 #define MAX_INTERCEPT_COUNT 4
+#define COMP_RETURN_CAPS_COUNT 2
 
 #include "compartment.h"
 
 #define ENV_FIELDS_CNT 1
 extern const char* comp_env_fields[ENV_FIELDS_CNT];
 extern char** environ;
+extern void* __capability comp_return_caps[COMP_RETURN_CAPS_COUNT];
 
 const char* get_env_str(const char*);
 int manager___vdso_clock_gettime(clockid_t, struct timespec*);
@@ -44,25 +46,31 @@ void my_free(void* ptr);
  * Compartment function intercepts
  ******************************************************************************/
 
-// Intercept functions
-time_t manager_time();
-
 struct func_intercept {
     char* func_name;
     uintptr_t redirect_func;
-    void* __capability intercept_pcc;
     void* __capability intercept_ddc;
+    void* __capability intercept_pcc;
+    void* __capability redirect_cap;
 };
 
+void setup_intercepts();
+void print_full_cap(uintcap_t);
+void intercept_wrapper(void* to_call_fn);
 
-static const struct func_intercept comp_intercept_funcs[] = {
+// Intercept functions
+time_t manager_time();
+
+static const struct func_intercept to_intercept_funcs[] = {
     /* vDSO funcs */
     { "time", (uintptr_t) manager_time },
     //"printf",
     /* Mem funcs */
-    { "malloc", (uintptr_t) my_malloc },
-    { "realloc", (uintptr_t) my_realloc },
-    { "free", (uintptr_t) my_free },
+    //{ "malloc", (uintptr_t) my_malloc },
+    //{ "realloc", (uintptr_t) my_realloc },
+    //{ "free", (uintptr_t) my_free },
 };
+#define INTERCEPT_FUNC_COUNT sizeof(to_intercept_funcs) / sizeof(to_intercept_funcs[0])
+extern struct func_intercept comp_intercept_funcs[INTERCEPT_FUNC_COUNT];
 
 #endif // _MANAGER_H

--- a/include/manager.h
+++ b/include/manager.h
@@ -6,46 +6,20 @@
 #include <unistd.h>
 #include <dlfcn.h>
 #include <sys/auxv.h>
+#include <stdarg.h>
+#include <stdio.h>
 
 // vDSO wrapper needed includes
 #include <sys/time.h>
 
-/*******************************************************************************
- * Compartment
- ******************************************************************************/
-
-#define MAX_INTERCEPT_COUNT 4
-#define COMP_RETURN_CAPS_COUNT 2
-
-#include "compartment.h"
-
-#define ENV_FIELDS_CNT 1
-extern const char* comp_env_fields[ENV_FIELDS_CNT];
-extern char** environ;
-extern void* __capability comp_return_caps[COMP_RETURN_CAPS_COUNT];
-
-const char* get_env_str(const char*);
-int manager___vdso_clock_gettime(clockid_t, struct timespec*);
-
-struct Compartment* manager_find_compartment_by_addr(void*);
-struct Compartment* manager_find_compartment_by_ddc(void* __capability);
-
-/*******************************************************************************
- * Memory allocation
- ******************************************************************************/
-
-#include "mem_mng.h"
-
 extern void* __capability manager_ddc;
 
-void* my_realloc(void*, size_t);
-void* my_malloc(size_t);
-void my_free(void* ptr);
-
 /*******************************************************************************
- * Compartment function intercepts
+ * Intercepts
  ******************************************************************************/
 
+/* Data required to perform the transition for an intercepted function
+ */
 struct func_intercept {
     char* func_name;
     uintptr_t redirect_func;
@@ -54,23 +28,70 @@ struct func_intercept {
     void* __capability redirect_cap;
 };
 
-void setup_intercepts();
-void print_full_cap(uintcap_t);
+/* This function expects the argument be passed in `x10`, rather than `x0`. It
+ * is expected to be called only in very specific circumstances, and the
+ * signature is more illustrative than functional. As such, it shouldn't be
+ * called from a C context, as that will most likely break things.
+ */
 void intercept_wrapper(void* to_call_fn);
 
-// Intercept functions
-time_t manager_time();
+void setup_intercepts();
+
+time_t manager_time(time_t*);
+void* my_realloc(void*, size_t);
+void* my_malloc(size_t);
+void my_free(void*);
+int my_fprintf(FILE*, const char*, ...);
 
 static const struct func_intercept to_intercept_funcs[] = {
     /* vDSO funcs */
     { "time", (uintptr_t) manager_time },
-    //"printf",
     /* Mem funcs */
-    //{ "malloc", (uintptr_t) my_malloc },
-    //{ "realloc", (uintptr_t) my_realloc },
-    //{ "free", (uintptr_t) my_free },
+    { "malloc", (uintptr_t) my_malloc },
+    { "realloc", (uintptr_t) my_realloc },
+    { "free", (uintptr_t) my_free },
+    { "fprintf", (uintptr_t) my_fprintf },
 };
+//
+// Functions to be intercepted and associated data
 #define INTERCEPT_FUNC_COUNT sizeof(to_intercept_funcs) / sizeof(to_intercept_funcs[0])
 extern struct func_intercept comp_intercept_funcs[INTERCEPT_FUNC_COUNT];
+
+/*******************************************************************************
+ * Utility Functions
+ ******************************************************************************/
+
+void print_full_cap(uintcap_t);
+
+/*******************************************************************************
+ * Compartment
+ ******************************************************************************/
+
+// Number of capabilities required to perform a transition
+#define COMP_RETURN_CAPS_COUNT 2
+
+// Capabilities required to transition back into the manager once compartment
+// execution has finished
+extern void* __capability comp_return_caps[COMP_RETURN_CAPS_COUNT];
+
+struct Compartment* manager_find_compartment_by_addr(void*);
+struct Compartment* manager_find_compartment_by_ddc(void* __capability);
+
+#include "compartment.h"
+
+// TODO stack setup when we transition into the compartment; unsure if needed,
+// but keep for now, just in case
+#define ENV_FIELDS_CNT 1
+extern const char* comp_env_fields[ENV_FIELDS_CNT];
+extern char** environ;
+const char* get_env_str(const char*);
+int manager___vdso_clock_gettime(clockid_t, struct timespec*);
+// END TODO
+
+/*******************************************************************************
+ * Memory allocation
+ ******************************************************************************/
+
+#include "mem_mng.h"
 
 #endif // _MANAGER_H

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -3,5 +3,6 @@ add_library(chcomp STATIC
     manager.c
     mem_mng.c
     compartment.c
+    transition.S
     )
 target_include_directories(chcomp PRIVATE ${INCLUDE_DIR})

--- a/src/manager.c
+++ b/src/manager.c
@@ -1,8 +1,10 @@
 #include "manager.h"
 
 const char* comp_env_fields[] = { "PATH", };
+void* __capability comp_return_caps[COMP_RETURN_CAPS_COUNT];
 void* __capability manager_ddc = NULL;
 struct Compartment* loaded_comp = NULL; // TODO
+struct func_intercept comp_intercept_funcs[INTERCEPT_FUNC_COUNT];
 
 const char*
 get_env_str(const char* env_name)
@@ -15,6 +17,10 @@ get_env_str(const char* env_name)
     }
     return NULL;
 }
+
+/*******************************************************************************
+ * Intercept functions
+ ******************************************************************************/
 
 time_t
 manager_time(time_t* t)
@@ -52,6 +58,39 @@ my_free(void* ptr)
     struct Compartment* comp = manager_find_compartment_by_ddc(cheri_ddc_get());
     manager_free_mem_alloc(comp, ptr); // TODO
     return;
+}
+
+/*******************************************************************************
+ * Utility functions
+ ******************************************************************************/
+
+void print_full_cap(uintcap_t cap) {
+    uint32_t words[4];  // Hack to demonstrate! In real code, be more careful about sizes, etc.
+    printf("0x%d", cheri_tag_get(cap) ? 1 : 0);
+    memcpy(words, &cap, sizeof(cap));
+    for (int i = 3; i >= 0; i--) {
+        printf("_%08x", words[i]);
+    }
+    printf("\n");
+}
+
+/* Setup required capabilities on the heap to jump from within compartments via
+ * a context switch
+ */
+void
+setup_intercepts()
+{
+    for (size_t i = 0; i < sizeof(to_intercept_funcs) / sizeof(to_intercept_funcs[0]); ++i)
+    {
+        comp_intercept_funcs[i].func_name = to_intercept_funcs[i].func_name;
+        comp_intercept_funcs[i].redirect_func = to_intercept_funcs[i].redirect_func;
+        comp_intercept_funcs[i].intercept_ddc = manager_ddc;
+        comp_intercept_funcs[i].intercept_pcc = cheri_address_set(cheri_pcc_get(), (uintptr_t) intercept_wrapper);
+        comp_intercept_funcs[i].redirect_cap = cheri_address_set(manager_ddc, (uintptr_t) &comp_intercept_funcs[i].intercept_ddc);
+        print_full_cap((uintcap_t) comp_intercept_funcs[i].redirect_cap);
+    }
+    comp_return_caps[0] = manager_ddc;
+    comp_return_caps[1] = cheri_address_set(cheri_pcc_get(), (uintptr_t) comp_exec_out);
 }
 
 struct Compartment*

--- a/src/mem_mng.c
+++ b/src/mem_mng.c
@@ -32,7 +32,6 @@ manager_insert_new_alloc(struct Compartment* comp, struct mem_alloc* to_insert)
 
     if (comp->alloc_head->ptr > to_insert->ptr)
     {
-        // TODO do we need `to_insert->prev_alloc` set?
         to_insert->next_alloc = comp->alloc_head;
         to_insert->prev_alloc = NULL;
         comp->alloc_head->prev_alloc = to_insert;

--- a/src/mem_mng.c
+++ b/src/mem_mng.c
@@ -2,6 +2,13 @@
 
 // MEM TODO
 
+/* An initial design of a simple bump allocator. This is here more to have
+ * something intercept `malloc` calls from the compartment, and might be
+ * scrapped in favour of something useful. The only requirement is that we are
+ * able to restrict what area of the memory we want to manage to the
+ * compartment scratch memory space
+ */
+
 void*
 manager_register_mem_alloc(struct Compartment* comp, size_t mem_size)
 {

--- a/src/transition.S
+++ b/src/transition.S
@@ -1,0 +1,48 @@
+.text
+.balign 4
+.global intercept_wrapper
+.type intercept_wrapper, "function"
+// TODO restore c29
+intercept_wrapper:
+    mrs c28, ddc
+    msr ddc, c29
+    stp clr, c28, [sp, #-32]!
+    blr x10
+    ldp clr, c28, [sp], #32
+    msr ddc, c28
+    mov x29, #0
+    ret
+
+.global compartment_transition_out
+.type compartment_transition_out, "function"
+compartment_transition_out:
+    stp c29, clr, [sp, #-32]!
+    ldpblr c29, [c11] // TODO save c11?
+    ldp c29, clr, [sp], #32
+    ret
+compartment_transition_out_end:
+
+/* comp_exec_in(void* comp_sp, void* __capability comp_ddc, void* fn) */
+.global comp_exec_in
+.type comp_exec_in, "function"
+comp_exec_in:
+    stp lr, x29, [sp, #-16]!
+    mov x19, sp
+
+    mov sp, x0
+    msr DDC, c1
+    blr x2
+
+    adr x11, comp_return_caps
+    cvtp c11, x11
+    ldpbr c29, [c11]
+
+// Expect DDC in c29, reset `sp` and `clr`
+// result should be in `x0`
+.global comp_exec_out
+.type comp_exec_out, "function"
+comp_exec_out:
+    msr DDC, c29
+    mov sp, x19
+    ldp lr, x29, [sp], #16
+    ret

--- a/src/transition.S
+++ b/src/transition.S
@@ -1,5 +1,10 @@
 .text
 .balign 4
+
+/* Wrapper to an intercept function, executed within a manager context;
+ * required in order to maintain a consisten execution state. This also manages
+ * setting the `DDC` as needed.
+ */
 .global intercept_wrapper
 .type intercept_wrapper, "function"
 // TODO restore c29
@@ -13,16 +18,22 @@ intercept_wrapper:
     mov x29, #0
     ret
 
+/* Function to transition out of a compartment; essentially the `ldpblr`
+ * transition instruction, and some book-keeping.
+ */
 .global compartment_transition_out
 .type compartment_transition_out, "function"
 compartment_transition_out:
     stp c29, clr, [sp, #-32]!
-    ldpblr c29, [c11] // TODO save c11?
+    ldpblr c29, [c11]
     ldp c29, clr, [sp], #32
     ret
 compartment_transition_out_end:
 
 /* comp_exec_in(void* comp_sp, void* __capability comp_ddc, void* fn) */
+/* Instructions to enter a compartment. There is no `ret`, as we need to
+ * perform a context switch upon exiting, which is done via `ldpbr`
+ */
 .global comp_exec_in
 .type comp_exec_in, "function"
 comp_exec_in:
@@ -37,8 +48,11 @@ comp_exec_in:
     cvtp c11, x11
     ldpbr c29, [c11]
 
-// Expect DDC in c29, reset `sp` and `clr`
-// result should be in `x0`
+/* Instructions to perform once a compartment has finished execution.
+ *
+ * Expects `DDC` in c29, resets `sp` and `clr` to continue execution for the
+ * manager. The result of the compartment is expected in `x0`.
+ */
 .global comp_exec_out
 .type comp_exec_out, "function"
 comp_exec_out:

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -32,3 +32,4 @@ endfunction()
 
 new_proj_test(simple TRUE)
 new_proj_test(test_map FALSE)
+new_proj_test(time TRUE)

--- a/tests/hello_world_comps.c
+++ b/tests/hello_world_comps.c
@@ -8,8 +8,6 @@ main(int argc, char** argv)
 {
     // Initial setup
     manager_ddc = cheri_ddc_get();
-    /*print_full_cap((uintcap_t) testing);*/
-    print_full_cap((uintcap_t) manager_ddc);
     setup_intercepts();
 
     assert(argc == 2);
@@ -20,7 +18,6 @@ main(int argc, char** argv)
     char* comp_argv[] = { file };
     hw_comp->argv = comp_argv;
     log_new_comp(hw_comp);
-    /*comp_print(hw_comp);*/
     comp_map(hw_comp);
     int comp_result = comp_exec(hw_comp);
     comp_clean(hw_comp);

--- a/tests/hello_world_comps.c
+++ b/tests/hello_world_comps.c
@@ -6,9 +6,12 @@ extern struct Compartment* loaded_comp;
 int
 main(int argc, char** argv)
 {
+    // Initial setup
     manager_ddc = cheri_ddc_get();
-    time_t t_buf;
-    time(&t_buf);
+    /*print_full_cap((uintcap_t) testing);*/
+    print_full_cap((uintcap_t) manager_ddc);
+    setup_intercepts();
+
     assert(argc == 2);
     char* file = argv[1];
     struct Compartment* hw_comp = comp_from_elf(file);
@@ -17,11 +20,9 @@ main(int argc, char** argv)
     char* comp_argv[] = { file };
     hw_comp->argv = comp_argv;
     log_new_comp(hw_comp);
-    comp_print(hw_comp);
+    /*comp_print(hw_comp);*/
     comp_map(hw_comp);
     int comp_result = comp_exec(hw_comp);
-
     comp_clean(hw_comp);
-    free(comp_argv[0]);
     return comp_result;
 }

--- a/tests/test_map.c
+++ b/tests/test_map.c
@@ -4,6 +4,8 @@ int
 main(int argc, char** argv)
 {
     manager_ddc = cheri_ddc_get();
+    setup_intercepts();
+
     char* file = "./simple";
     struct Compartment* hw_comp = comp_from_elf(file);
     hw_comp->argc = 1;

--- a/tests/time.c
+++ b/tests/time.c
@@ -1,0 +1,9 @@
+#include <stdio.h>
+#include <sys/time.h>
+
+int
+main(void)
+{
+    time_t seconds = time(NULL);
+    return 0;
+}


### PR DESCRIPTION
Improve the compartment transition process. This includes storing required information upon entering a compartment, intercepting functions within the compartment which need special privileges (e.g., vDSO functions, memory allocation), and restoring the manager state when returning from the compartment. Of particular interest should be `comp_add_intercept` changes within `compartment.c` and the code in `transition.S` (where all assembly has been moved for readability).

Some particular comments of interest are regarding the procedure call standard, and ensuring registers are correctly used.

This is currently a draft, as `buildbot` stuff needs updating.