### PR TITLE
Fix testing infrastructure

### DIFF
--- a/.buildbot.sh
+++ b/.buildbot.sh
@@ -2,13 +2,6 @@
 
 set -e
 
-# Only execute on `morello-hybrid`
-if [ "$1" != "morello-hybrid" ]
-then
-    echo "Expecting `morello-hybrid` buildbot argument."
-    exit 0
-fi
-
 build_dir="$(pwd)/build"
 src_dir="$(pwd)"
 cheri_dir="/home/buildbot/cheri/output"
@@ -36,12 +29,11 @@ cmake --build $build_dir
 
 # Set arguments for Morello hybrid instance
 export SSHPORT=10086
-export PYTHONPATH="/home/buildbot/build/test-scripts"
 
 args=(
     --architecture morello-hybrid
     # Qemu System to use
-    --qemu-cmd $cheri_dir/morello-sdk/bin/qemu-system-morello
+    --qemu-cmd $cheri_dir/sdk/bin/qemu-system-morello
     --bios edk2-aarch64-code.fd
     --disk-image $cheri_dir/cheribsd-morello-hybrid.img
     # Required build-dir in CheriBSD

--- a/.run_cheri_qemu_and_test.py
+++ b/.run_cheri_qemu_and_test.py
@@ -26,7 +26,8 @@ def run_tests(qemu: boot_cheribsd.QemuCheriBSDInstance, args: argparse.Namespace
 
     # Run command on host to test the executed client
     os.chdir(f"{args.build_dir}/build")
-    subprocess.run(["/usr/bin/ctest", "-V", "--output-on-failure"], check=True)
+    subprocess.run([f"{args.build_dir}/tests/run_test.sh", "prep"], check=True)
+    subprocess.run(["ctest", "--output-on-failure"], check=True)
     return True
 
 if __name__ == '__main__':

--- a/bors.toml
+++ b/bors.toml
@@ -1,6 +1,6 @@
 # Sourced from
 # https://github.com/capablevms/cheri-examples/blob/master/bors.toml
-status = ["buildbot/capablevms-test-script"]
+status = ["buildbot/ci-builder"]
 
 timeout_sec = 600 # 10 minutes
 

--- a/include/manager.h
+++ b/include/manager.h
@@ -28,10 +28,12 @@ struct func_intercept {
     void* __capability redirect_cap;
 };
 
-/* This function expects the argument be passed in `x10`, rather than `x0`. It
- * is expected to be called only in very specific circumstances, and the
- * signature is more illustrative than functional. As such, it shouldn't be
- * called from a C context, as that will most likely break things.
+/* This function expects the argument be passed in `x10`, rather than `x0`, as
+ * well as using `c29` as an argument for the DDC to transition to in order to
+ * allow the intercept to work. It is expected to be called only in very
+ * specific circumstances, and the signature is more illustrative than
+ * functional. As such, it shouldn't be called from a C context, as that will
+ * most likely break things.
  */
 void intercept_wrapper(void* to_call_fn);
 
@@ -43,6 +45,7 @@ size_t manager_fread(void* __restrict, size_t, size_t, FILE* __restrict);
 size_t manager_fwrite(void* __restrict, size_t, size_t, FILE* __restrict);
 int manager_fclose(FILE*);
 int manager_getc(FILE*);
+int manager_fputc(int, FILE*);
 int manager___srget(FILE*);
 
 void* my_realloc(void*, size_t);
@@ -64,6 +67,7 @@ static const struct func_intercept to_intercept_funcs[] = {
     { "fwrite"  , (uintptr_t) manager_fwrite  },
     { "fclose"  , (uintptr_t) manager_fclose  },
     { "getc"    , (uintptr_t) manager_getc    },
+    { "fputc"   , (uintptr_t) manager_fputc   },
     { "__srget" , (uintptr_t) manager___srget },
 };
 //

--- a/src/manager.c
+++ b/src/manager.c
@@ -62,6 +62,12 @@ manager_fwrite(void* __restrict buf, size_t size, size_t count, FILE* __restrict
 }
 
 int
+manager_fputc(int chr, FILE* stream)
+{
+    return fputc(chr, stream);
+}
+
+int
 manager_fclose(FILE* fp)
 {
     int res = fclose(fp);

--- a/src/transition.S
+++ b/src/transition.S
@@ -7,15 +7,15 @@
  */
 .global intercept_wrapper
 .type intercept_wrapper, "function"
-// TODO restore c29
 intercept_wrapper:
+    stp c28, c29, [sp, #-64]!
     mrs c28, ddc
     msr ddc, c29
-    stp clr, c28, [sp, #-32]!
+    stp clr, c28, [sp, #32]
     blr x10
-    ldp clr, c28, [sp], #32
+    ldp clr, c28, [sp, #32]
     msr ddc, c28
-    mov x29, #0
+    ldp c28, c29, [sp], #64
     ret
 
 /* Function to transition out of a compartment; essentially the `ldpblr`

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -9,36 +9,43 @@ target_link_libraries(hwwrap PUBLIC chcomp)
 # Library test functions
 
 function(new_proj_test test_name compartment)
+    string(FIND ${test_name} " " test_name_delim_pos)
+    if (NOT ${test_name_delim_pos} EQUAL "-1")
+        string(SUBSTRING ${test_name} ${test_name_delim_pos} "-1" test_args)
+        string(SUBSTRING ${test_name} "0" ${test_name_delim_pos} test_name)
+    endif()
     add_executable(${test_name}
         ${test_name}.c)
-    target_link_libraries(${test_name} PRIVATE chcomp)
-    target_include_directories(${test_name} PRIVATE ${INCLUDE_DIR})
+    target_link_libraries(${test_name} PRIVATE chcomp lualib dl m)
+    target_include_directories(${test_name} PRIVATE ${INCLUDE_DIR} ${LUA_INCLUDE_DIR})
     if(${compartment})
         target_compile_options(${test_name} PRIVATE -static)
         target_link_options(${test_name} PRIVATE -static "LINKER:-image-base=0x1000000")
+        add_test(NAME ${test_name}
+                 COMMAND ${CMAKE_SOURCE_DIR}/tests/run_test.sh comp $<TARGET_FILE:${test_name}> ${test_args})
+    else()
+        add_test(NAME ${test_name}
+                 COMMAND ${CMAKE_SOURCE_DIR}/tests/run_test.sh test $<TARGET_FILE:${test_name}>)
     endif()
-    add_test(NAME ${test_name}
-             COMMAND ${CMAKE_SOURCE_DIR}/tests/run_test.sh $<TARGET_FILE:${test_name}>)
-endfunction()
-
-function(new_proj_lua_test test_name)
-    add_executable(${test_name}
-        ${test_name}.c)
-    add_dependencies(${test_name} lualib)
-    target_link_libraries(${test_name} PRIVATE lualib dl m)
-    target_include_directories(${test_name} PRIVATE ${LUA_INCLUDE_DIR})
-    target_compile_options(${test_name} PRIVATE -static)
-    target_link_options(${test_name} PRIVATE -static "LINKER:-image-base=0x1000000")
-    add_test(NAME ${test_name}
-             COMMAND ${CMAKE_SOURCE_DIR}/tests/run_test.sh $<TARGET_FILE:${test_name}> ${ARGV2})
 endfunction()
 
 # Library tests
+set(func_tests
+    "test_map"
+    )
 
-new_proj_test(simple TRUE)
-new_proj_test(time TRUE)
+set(comp_tests
+    "simple"
+    "time"
+    "lua_simple"
+    "lua_script"
+    )
 
-new_proj_test(test_map FALSE)
+foreach(comp_t IN LISTS comp_tests)
+    new_proj_test(${comp_t} TRUE)
+endforeach()
 
-new_proj_lua_test(lua_simple)
-new_proj_lua_test(lua_script ${TEST_DIR}/hello_world.lua)
+foreach(func_t IN LISTS func_tests)
+    new_proj_test(${func_t} FALSE)
+endforeach()
+

--- a/tests/run_test.sh
+++ b/tests/run_test.sh
@@ -3,15 +3,31 @@
 set -x
 set -e
 
-if [ $# -ne 1 ]
-then
-    echo "Expected one parameter: path to executable."
-    exit 1
-fi
-
+# CheriBSD setup
 CHERIBSD_PORT=10086
 CHERIBSD_USER=root
 CHERIBSD_HOST=localhost
+CHERIBSD_TEST_DIR=./testing
 
-scp -o "StrictHostKeyChecking no" -P $CHERIBSD_PORT $1 $CHERIBSD_USER@$CHERIBSD_HOST:
-ssh -o "StrictHostKeyChecking no" -p $CHERIBSD_PORT $CHERIBSD_USER@$CHERIBSD_HOST -t ./$(basename $1)
+# Testing variables
+wrapper_name="./hwwrap"
+test_name=$2
+test_args=$3
+
+if [ $1 == "comp" ]
+then
+    scp -o "StrictHostKeyChecking no" -P $CHERIBSD_PORT $test_name $CHERIBSD_USER@$CHERIBSD_HOST:${CHERIBSD_TEST_DIR}/
+    ssh -o "StrictHostKeyChecking no" -p $CHERIBSD_PORT $CHERIBSD_USER@$CHERIBSD_HOST -t "cd ${CHERIBSD_TEST_DIR} && $wrapper_name ./$(basename $test_name) $test_args"
+elif [ $1 == "test" ]
+then
+    scp -o "StrictHostKeyChecking no" -P $CHERIBSD_PORT $test_name $CHERIBSD_USER@$CHERIBSD_HOST:${CHERIBSD_TEST_DIR}/
+    ssh -o "StrictHostKeyChecking no" -p $CHERIBSD_PORT $CHERIBSD_USER@$CHERIBSD_HOST -t "cd ${CHERIBSD_TEST_DIR} && ./$(basename $test_name)"
+elif [ $1 == "prep" ]
+then
+    FILES_TO_PREP=(./tests/hwwrap ../tests/hello_world.lua)
+    ssh -o "StrictHostKeyChecking no" -p $CHERIBSD_PORT $CHERIBSD_USER@$CHERIBSD_HOST -t "mkdir -p ${CHERIBSD_TEST_DIR}"
+    scp -o "StrictHostKeyChecking no" -P $CHERIBSD_PORT ${FILES_TO_PREP[@]} $CHERIBSD_USER@$CHERIBSD_HOST:${CHERIBSD_TEST_DIR}/
+else
+    echo "Unsupported operation given: $1. Expected [ prep, test, comp ]."
+    exit 1
+fi


### PR DESCRIPTION
There are two types of tests: ones meant to run directly on a CheriBSD
machine, and ones meant to be ran as a compartment, using a binary with
our library. Before, we were not actually running the compartment tests
as compartments, just doing so directly. This fixes this, as well as
slightly touching on the testing implementation design (no functional
changes).