### PR TITLE
Compartment configuration files

### DIFF
--- a/.buildbot.sh
+++ b/.buildbot.sh
@@ -13,6 +13,10 @@ git submodule update --init
 lua_dir="$src_dir/third-party/lua"
 patch -d $lua_dir -i ../lua.patch
 
+# Apply toml patch
+toml_dir="$src_dir/third_party/tomlc99"
+patch -d $toml_dir -i ../toml.patch
+
 # Build project locally
 export CC=$cheri_dir/morello-sdk/bin/clang
 export CFLAGS="--config cheribsd-morello-hybrid.cfg"

--- a/.buildbot.sh
+++ b/.buildbot.sh
@@ -14,11 +14,12 @@ lua_dir="$src_dir/third-party/lua"
 patch -d $lua_dir -i ../lua.patch
 
 # Apply toml patch
-toml_dir="$src_dir/third_party/tomlc99"
-patch -d $toml_dir -i ../toml.patch
+toml_dir="$src_dir/third-party/tomlc99"
+patch -d $toml_dir -i ../tomlc99.patch
 
 # Build project locally
 export CC=$cheri_dir/morello-sdk/bin/clang
+export AR=$cheri_dir/morello-sdk/bin/llvm-ar
 export CFLAGS="--config cheribsd-morello-hybrid.cfg"
 export ASMFLAGS="--config cheribsd-morello-hybrid.cfg"
 

--- a/.gitmodules
+++ b/.gitmodules
@@ -3,4 +3,4 @@
 	url = https://github.com/lua/lua/
 [submodule "third-party/tomlc99"]
 	path = third-party/tomlc99
-	url = https://github.com/cktan/tomlc99.git
+	url = https://github.com/cktan/tomlc99

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,11 +21,34 @@ add_custom_target(
     lua
     DEPENDS ${LUA_LIB_PATH}
 )
-add_library(lualib STATIC IMPORTED GLOBAL)
+add_library(lualib STATIC IMPORTED)
 add_dependencies(lualib lua)
 set_target_properties(lualib
     PROPERTIES
     IMPORTED_LOCATION ${LUA_LIB_PATH}
+)
+
+# Build tomlc99
+set(TOML_DIR ${CMAKE_SOURCE_DIR}/third-party/tomlc99)
+set(TOML_INSTALL_DIR ${TOML_DIR}/build)
+set(TOML_LIB_PATH ${TOML_INSTALL_DIR}/lib/libtoml.a)
+set(TOML_INCLUDE_DIR ${TOML_INSTALL_DIR}/include)
+
+add_custom_command(
+    OUTPUT ${TOML_LIB_PATH}
+    COMMAND make install prefix=${TOML_INSTALL_DIR}
+    WORKING_DIRECTORY ${TOML_DIR}
+)
+
+add_custom_target(
+    toml
+    DEPENDS ${TOML_LIB_PATH}
+)
+add_library(tomllib SHARED IMPORTED)
+add_dependencies(tomllib toml)
+set_target_properties(tomllib
+    PROPERTIES
+    IMPORTED_LOCATION ${TOML_LIB_PATH}
 )
 
 # Build sources

--- a/include/compartment.h
+++ b/include/compartment.h
@@ -30,7 +30,7 @@
 
 struct func_intercept;
 void compartment_transition_out();
-int64_t comp_exec_in(void*, void* __capability, void*, void**, size_t);
+int64_t comp_exec_in(void*, void* __capability, void*, void*, size_t, char*);
 void comp_exec_out();
 
 // Declare built-in function for cache synchronization:
@@ -55,12 +55,27 @@ struct intercept_patch
     void* __capability manager_cap;
 };
 
+/* Struct representing configuration data for one entry point; this is just
+ * information that we expect to appear in the compartment, as given by its
+ * compartment configuration file
+ */
+struct ConfigEntryPoint
+{
+    const char* name;
+    size_t arg_count;
+    char** args_type;
+    size_t all_args_size;
+    char* args_sizes;
+};
+
 /* Struct representing a valid entry point to a compartment
  */
 struct entry_point
 {
-    char* fn_name;
+    const char* fn_name;
     uintptr_t fn_addr;
+    size_t arg_count;
+    char** arg_types;
 };
 
 /* Struct representing one segment of an ELF binary.
@@ -95,7 +110,7 @@ struct Compartment
     size_t size;
     uintptr_t base;
     size_t entry_point_count;
-    struct entry_point* comp_fns[4]; // TODO
+    struct entry_point** comp_fns; // TODO
     uintptr_t* relas;
     size_t relas_cnt;
     bool mapped;
@@ -132,13 +147,13 @@ extern struct Compartment** comps;
 
 int entry_point_cmp(const void*, const void*);
 struct Compartment* comp_init();
-struct Compartment* comp_from_elf(char*, char**);
+struct Compartment* comp_from_elf(char*, struct ConfigEntryPoint*, size_t);
 void comp_register_ddc(struct Compartment*);
 void comp_add_intercept(struct Compartment*, uintptr_t, struct func_intercept);
 void comp_stack_push(struct Compartment*, const void*, size_t);
 void comp_map(struct Compartment*);
 void comp_map_full(struct Compartment*);
-int64_t comp_exec(struct Compartment*, char*, void**, size_t);
+int64_t comp_exec(struct Compartment*, char*, void*, size_t, char*);
 void comp_clean(struct Compartment*);
 
 void log_new_comp(struct Compartment*);

--- a/include/manager.h
+++ b/include/manager.h
@@ -12,6 +12,9 @@
 // vDSO wrapper needed includes
 #include <sys/time.h>
 
+// Third-party libraries
+#include "toml.h"
+
 extern void* __capability manager_ddc;
 
 /*******************************************************************************
@@ -88,6 +91,9 @@ void print_full_cap(uintcap_t);
 // Number of capabilities required to perform a transition
 #define COMP_RETURN_CAPS_COUNT 2
 
+// Compartment configuration file suffix
+extern const char* comp_config_suffix;
+
 // Capabilities required to transition back into the manager once compartment
 // execution has finished
 extern void* __capability comp_return_caps[COMP_RETURN_CAPS_COUNT];
@@ -105,6 +111,13 @@ extern char** environ;
 const char* get_env_str(const char*);
 int manager___vdso_clock_gettime(clockid_t, struct timespec*);
 // END TODO
+
+char get_size_of_str_type(char*);
+struct ConfigEntryPoint* parse_compartment_config(FILE*, size_t*);
+void clean_compartment_config(struct ConfigEntryPoint*, size_t);
+struct ConfigEntryPoint get_entry_point(char*, struct ConfigEntryPoint*, size_t);
+void* prepare_compartment_args(char** args, struct ConfigEntryPoint);
+struct ConfigEntryPoint* set_default_entry_point(struct ConfigEntryPoint*);
 
 /*******************************************************************************
  * Memory allocation

--- a/include/manager.h
+++ b/include/manager.h
@@ -112,7 +112,15 @@ const char* get_env_str(const char*);
 int manager___vdso_clock_gettime(clockid_t, struct timespec*);
 // END TODO
 
-char get_size_of_str_type(char*);
+union arg_holder
+{
+    int i;
+    long l;
+    char c;
+    long long ll;
+    unsigned long long ull;
+};
+
 struct ConfigEntryPoint* parse_compartment_config(FILE*, size_t*);
 void clean_compartment_config(struct ConfigEntryPoint*, size_t);
 struct ConfigEntryPoint get_entry_point(char*, struct ConfigEntryPoint*, size_t);

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -5,4 +5,5 @@ add_library(chcomp STATIC
     compartment.c
     transition.S
     )
-target_include_directories(chcomp PRIVATE ${INCLUDE_DIR})
+target_include_directories(chcomp PRIVATE ${INCLUDE_DIR} ${TOML_INCLUDE_DIR})
+target_link_libraries(chcomp PRIVATE tomllib)

--- a/src/compartment.c
+++ b/src/compartment.c
@@ -504,7 +504,7 @@ void ddc_set(void *__capability cap) {
  * prefer to default to `main` in that case
  */
 int64_t
-comp_exec(struct Compartment* to_exec, char* fn_name, void* args, size_t args_count, char* args_sizes)
+comp_exec(struct Compartment* to_exec, char* fn_name, void* args, size_t args_count)
 {
     assert(to_exec->mapped && "Attempting to execute an unmapped compartment.\n");
 
@@ -542,7 +542,7 @@ comp_exec(struct Compartment* to_exec, char* fn_name, void* args, size_t args_co
         /*arg = cheri_perms_and(arg, !(CHERI_PERM_STORE | CHERI_PERM_EXECUTE));*/
         /*args_caps[i] = arg;*/
     /*}*/
-    result = comp_exec_in((void*) to_exec->stack_pointer, to_exec->ddc, fn, args, args_count, args_sizes);
+    result = comp_exec_in((void*) to_exec->stack_pointer, to_exec->ddc, fn, args, args_count);
 
     return result;
 }

--- a/src/compartment.c
+++ b/src/compartment.c
@@ -53,15 +53,14 @@ entry_point_cmp(const void* val1, const void* val2)
  * a `struct Compartment`. At this point, we only read data.
  */
 struct Compartment*
-comp_from_elf(char* filename, char** entry_points)
+comp_from_elf(char* filename, struct ConfigEntryPoint* entry_points, size_t entry_point_count)
 {
     struct Compartment* new_comp = comp_init();
     int pread_res;
-    if (!entry_points)
-    {
-        char* main_entry[1] =  { "main" };
-        entry_points = main_entry;
-    }
+
+    assert(entry_points);
+    assert(entry_point_count > 0);
+    new_comp->comp_fns = malloc(entry_point_count * sizeof(struct entry_point));
 
     // Read elf headers
     Elf64_Ehdr comp_ehdr;
@@ -183,20 +182,20 @@ comp_from_elf(char* filename, char** entry_points)
 
             size_t syms_count = comp_symtb_hdr.sh_size / sizeof(Elf64_Sym);
             Elf64_Sym curr_sym;
-            char** syms_to_find = entry_points;
-            size_t syms_to_find_count = sizeof(syms_to_find) / sizeof(syms_to_find[0]);
-            char** syms_found = malloc(syms_to_find_count);
+            size_t syms_to_find_count = entry_point_count;
+            const char** syms_found = malloc(syms_to_find_count);
             size_t syms_found_count = 0;
             for (size_t j = 0; j < syms_count; ++j)
             {
                 curr_sym = comp_symtb[j];
                 for (size_t k = 0; k < syms_to_find_count; ++k)
                 {
-                    if (!strcmp(syms_to_find[k], &comp_strtb[curr_sym.st_name])) // TODO entry point name
+                    if (!strcmp(entry_points[k].name, &comp_strtb[curr_sym.st_name]))
                     {
                         struct entry_point* new_entry_point = malloc(sizeof(struct entry_point));
-                        new_entry_point->fn_name = malloc(strlen(syms_to_find[k]) + 1);
-                        strcpy(new_entry_point->fn_name, syms_to_find[k]);
+                        new_entry_point->fn_name = entry_points[k].name;
+                        new_entry_point->arg_count = entry_points[k].arg_count;
+                        new_entry_point->arg_types = entry_points[k].args_type;
                         switch(new_comp->elf_type)
                         {
                             case ET_DYN:
@@ -217,7 +216,7 @@ comp_from_elf(char* filename, char** entry_points)
                         new_comp->comp_fns[new_comp->entry_point_count] =
                             new_entry_point;
                         new_comp->entry_point_count += 1;
-                        syms_found[syms_found_count] = syms_to_find[k];
+                        syms_found[syms_found_count] = entry_points[k].name;
                         syms_found_count += 1;
                     }
                     else
@@ -237,14 +236,14 @@ comp_from_elf(char* filename, char** entry_points)
         free(comp_strtb);
         if (syms_found_count != syms_to_find_count)
         {
-            char** syms_not_found = malloc(syms_to_find_count);
+            const char** syms_not_found = malloc(syms_to_find_count);
             size_t not_found_idx = 0;
             for (size_t i = 0; i < syms_to_find_count; ++i)
             {
                 bool not_found = true;
                 for (size_t j = 0; j < syms_found_count; ++j)
                 {
-                    if (!strcmp(syms_found[j], syms_to_find[i]))
+                    if (!strcmp(syms_found[j], entry_points[i].name))
                     {
                         not_found = false;
                         break;
@@ -252,7 +251,7 @@ comp_from_elf(char* filename, char** entry_points)
                 }
                 if (not_found)
                 {
-                    syms_not_found[not_found_idx] = syms_to_find[i];
+                    syms_not_found[not_found_idx] = entry_points[i].name;
                     not_found_idx += 1;
                 }
             }
@@ -495,10 +494,17 @@ void ddc_set(void *__capability cap) {
 
 /* Execute a mapped compartment, by jumping to the appropriate entry point.
  *
- * TODO the entry point is currently only the `main` function of a compartment
+ * The entry point is given as a function name in the `fn_name` argument, and
+ * arguments to be passed are tightly packed in `args`. The requested entry
+ * point must have been registered prior during compartment initialization, by
+ * calling `parse_compartment_config`, and passing an appropriate `.comp`
+ * config file.
+ *
+ * TODO casually ignore the situation where no compartment is passed, if we
+ * prefer to default to `main` in that case
  */
 int64_t
-comp_exec(struct Compartment* to_exec, char* fn_name, void** args, size_t args_count)
+comp_exec(struct Compartment* to_exec, char* fn_name, void* args, size_t args_count, char* args_sizes)
 {
     assert(to_exec->mapped && "Attempting to execute an unmapped compartment.\n");
 
@@ -536,7 +542,7 @@ comp_exec(struct Compartment* to_exec, char* fn_name, void** args, size_t args_c
         /*arg = cheri_perms_and(arg, !(CHERI_PERM_STORE | CHERI_PERM_EXECUTE));*/
         /*args_caps[i] = arg;*/
     /*}*/
-    result = comp_exec_in((void*) to_exec->stack_pointer, to_exec->ddc, fn, args, args_count);
+    result = comp_exec_in((void*) to_exec->stack_pointer, to_exec->ddc, fn, args, args_count, args_sizes);
 
     return result;
 }
@@ -559,7 +565,7 @@ comp_clean(struct Compartment* to_clean)
     }
     for (size_t i = 0; i < to_clean->entry_point_count; ++i)
     {
-        free(to_clean->comp_fns[i]->fn_name);
+        free((char*) to_clean->comp_fns[i]->fn_name);
         free(to_clean->comp_fns[i]);
     }
     free(to_clean);

--- a/src/manager.c
+++ b/src/manager.c
@@ -6,6 +6,8 @@ void* __capability manager_ddc = NULL;
 struct Compartment* loaded_comp = NULL; // TODO
 struct func_intercept comp_intercept_funcs[INTERCEPT_FUNC_COUNT];
 
+const char* comp_config_suffix = ".comp";
+
 const char*
 get_env_str(const char* env_name)
 {
@@ -193,4 +195,166 @@ struct Compartment*
 manager_find_compartment_by_ddc(void* __capability ddc)
 {
     return loaded_comp; // TODO
+}
+
+void
+toml_parse_error(char* error_msg, char* errbuf)
+{
+    printf("%s: %s\n", error_msg, errbuf);
+    exit(1);
+}
+
+char
+get_size_of_str_type(char* str_type)
+{
+    if (!strcmp(str_type, "int"))
+    {
+        return sizeof(int);
+    }
+    else if (!strcmp(str_type, "char"))
+    {
+        return sizeof(char);
+    }
+    else if (!strcmp(str_type, "long"))
+    {
+        return sizeof(long);
+    }
+    else if (!strcmp(str_type, "long long"))
+    {
+        return sizeof(long long);
+    }
+    else if (!strcmp(str_type, "unsigned long long"))
+    {
+        return sizeof(unsigned long long);
+    }
+    printf("Did not check for size of type %s!\n", str_type);
+    assert(false);
+}
+
+struct ConfigEntryPoint*
+parse_compartment_config(FILE* config_fd, size_t* entry_point_count)
+{
+    char toml_errbuf[200];
+    toml_table_t* tab = toml_parse_file(config_fd, toml_errbuf, sizeof(toml_errbuf));
+    if (!tab)
+    {
+        toml_parse_error("TOML table parse error", toml_errbuf);
+    }
+    *entry_point_count = toml_table_ntab(tab);
+    struct ConfigEntryPoint* entry_points = malloc(*entry_point_count * sizeof(struct ConfigEntryPoint));
+    for (size_t i = 0; i < *entry_point_count; ++i)
+    {
+        const char* fname = toml_key_in(tab, i);
+        assert(fname);
+        toml_table_t* curr_func = toml_table_in(tab, fname);
+        assert(curr_func);
+        toml_datum_t func_arg_count = toml_int_in(curr_func, "args_count");
+        assert(func_arg_count.ok);
+        toml_array_t* func_arg_types = toml_array_in(curr_func, "args_type");
+        assert(func_arg_types);
+
+        entry_points[i].name = fname;
+        entry_points[i].arg_count = func_arg_count.u.i;
+        entry_points[i].all_args_size = 0;
+        entry_points[i].args_type = malloc(func_arg_count.u.i * sizeof(char*));
+        entry_points[i].args_sizes = malloc(func_arg_count.u.i * sizeof(char));
+        for (size_t j = 0; j < toml_array_nelem(func_arg_types); ++j)
+        {
+            toml_datum_t func_arg_type = toml_string_at(func_arg_types, j);
+            entry_points[i].args_type[j] = malloc(strlen(func_arg_type.u.s) + 1);
+            strcpy(entry_points[i].args_type[j], func_arg_type.u.s);
+            char curr_arg_size = get_size_of_str_type(func_arg_type.u.s);
+            free(func_arg_type.u.s);
+            entry_points[i].all_args_size += curr_arg_size;
+            entry_points[i].args_sizes[j] = curr_arg_size;
+        }
+    }
+    return entry_points;
+}
+
+void
+clean_compartment_config(struct ConfigEntryPoint* cep, size_t entry_point_count)
+{
+    for (size_t i = 0; i < entry_point_count; ++i)
+    {
+        for (size_t j = 0; j < cep[i].arg_count; ++j)
+        {
+            free(cep[i].args_type[j]);
+        }
+        free(cep[i].args_type);
+        free(cep[i].args_sizes);
+    }
+    free(cep);
+}
+
+struct ConfigEntryPoint
+get_entry_point(char* entry_point_fn, struct ConfigEntryPoint* ceps, size_t cep_count)
+{
+    struct ConfigEntryPoint curr_ep;
+    while (cep_count != 0)
+    {
+        curr_ep = ceps[cep_count - 1];
+        if (!strcmp(curr_ep.name, entry_point_fn))
+        {
+            return curr_ep;
+        }
+        cep_count -= 1;
+    }
+    printf("Did not find entry point for function %s!\n", entry_point_fn);
+    assert(false);
+}
+
+void*
+prepare_compartment_args(char** args, struct ConfigEntryPoint cep)
+{
+    void* parsed_args = malloc(cep.all_args_size);
+    size_t allocated_args = 0;
+    void* arg_ptr;
+    for (size_t i = 0; i < cep.arg_count; ++i)
+    {
+        if (!strcmp(cep.args_type[i], "int"))
+        {
+            int tmp = atoi(args[i]);
+            arg_ptr = &tmp;
+        }
+        else if (!strcmp(cep.args_type[i], "long"))
+        {
+            long tmp = atol(args[i]);
+            arg_ptr = &tmp;
+        }
+        else if (!strcmp(cep.args_type[i], "char"))
+        {
+            arg_ptr = args[i];
+        }
+        else if (!strcmp(cep.args_type[i], "long long"))
+        {
+            long long tmp = atoll(args[i]);
+            arg_ptr = &tmp;
+        }
+        else if (!strcmp(cep.args_type[i], "unsigned long long"))
+        {
+            unsigned long long tmp = strtoull(args[i], NULL, 10);
+            arg_ptr = &tmp;
+        }
+        else
+        {
+            printf("Unhandled compartment argument type %s!\n", cep.args_type[i]);
+            assert(false);
+        }
+        memcpy(parsed_args + allocated_args, arg_ptr, cep.args_sizes[i]);
+        allocated_args += cep.args_sizes[i];
+    }
+    return parsed_args;
+}
+
+struct ConfigEntryPoint*
+set_default_entry_point(struct ConfigEntryPoint* cep)
+{
+    cep->name = malloc(strlen("main") + 1);
+    strcpy((char*) cep->name, "main");
+    cep->arg_count = 0;
+    cep->args_type = NULL;
+    cep->all_args_size = 0;
+    cep->args_sizes = NULL;
+    return cep;
 }

--- a/src/transition.S
+++ b/src/transition.S
@@ -31,7 +31,7 @@ compartment_transition_out:
 compartment_transition_out_end:
 
 /* comp_exec_in(void* comp_sp, void* __capability comp_ddc, void* fn,
-                void* args, size_t args_count, char* args_sizes) */
+                void* args, size_t args_count) */
 /* Instructions to enter a compartment. There is no `ret`, as we need to
  * perform a context switch upon exiting, which is done via `ldpbr`
  */
@@ -48,35 +48,23 @@ comp_exec_in:
 
     // Load params (only handle 3 params):
 loading_params:
-    cbz  x4, loaded_params
-    ldrb w6, [x5], #1 // Get size of argument to load in `x6`
-                      // Increment `x5` by 1 byte since it's `char`s
-    bl   load_param_by_size
-    mov  x0, x8       // Store one argument
-    add  x3, x3, x6   // Shift array pointer by size of argument
-    sub  x4, x4, #1
+    cbz  x4, loaded_params // Check if we loaded all parameters
+    bl   load_param
+    mov  x0, x5       // Store one argument
 
     cbz  x4, loaded_params
-    ldrb w6, [x5], #1
-    bl   load_param_by_size
-    mov  x1, x8
-    add  x3, x3, x6
-    sub  x4, x4, #1
+    bl   load_param
+    mov  x1, x5
 
     cbz  x4, loaded_params
-    ldrb w6, [x5], #1
-    bl   load_param_by_size
-    mov  x2, x8
-    add  x3, x3, x6
-    sub  x4, x4, #1
+    bl   load_param
+    mov  x2, x5
     b    loaded_params
 
-load_param_by_size:
-    neg  x7, x6, lsl #3 // Get number of bits to throw away (0 - x6 * 8)
-    ldr  x8, [x3]       // Load next 64 bits of argument
-    lsl  x8, x8, x7     // Shift left to remove unneeded upper bits,
-                        // shifting in 0s on the right
-    lsr  x8, x8, x7     // Shift back right, again shifting in 0s on the left
+load_param:
+    ldr  x5, [x3]
+    add  x3, x3, #8
+    sub  x4, x4, #1
     ret
 
 loaded_params:
@@ -84,9 +72,6 @@ loaded_params:
     mov x3, xzr
     mov x4, xzr
     mov x5, xzr
-    mov x6, xzr
-    mov x7, xzr
-    mov x8, xzr
 
     mov sp, x9
     msr DDC, c10

--- a/src/transition.S
+++ b/src/transition.S
@@ -30,7 +30,8 @@ compartment_transition_out:
     ret
 compartment_transition_out_end:
 
-/* comp_exec_in(void* comp_sp, void* __capability comp_ddc, void* fn, void** args, size_t args_count) */
+/* comp_exec_in(void* comp_sp, void* __capability comp_ddc, void* fn,
+                void* args, size_t args_count, char* args_sizes) */
 /* Instructions to enter a compartment. There is no `ret`, as we need to
  * perform a context switch upon exiting, which is done via `ldpbr`
  */
@@ -47,23 +48,39 @@ comp_exec_in:
 
     // Load params (only handle 3 params):
 loading_params:
-    cbz x4, loaded_params
-    ldr x0, [x3], #8
-    ldr x0, [x0]
-    sub x4, x4, #1
+    cbz  x4, loaded_params
+    ldrb w6, [x5], #1 // Get size of argument to load in `x6`
+                      // Increment `x5` by 1 byte since it's `char`s
+    bl   load_param_by_size
+    mov  x0, x8       // Store one argument
+    add  x3, x3, x6   // Shift array pointer by size of argument
+    sub  x4, x4, #1
 
-    cbz x4, loaded_params
-    ldr x1, [x3], #8
-    ldr x1, [x1]
-    sub x4, x4, #1
+    cbz  x4, loaded_params
+    ldrb w6, [x5], #1
+    bl   load_param_by_size
+    mov  x1, x8
+    add  x3, x3, x6
+    sub  x4, x4, #1
 
-    cbz x4, loaded_params
-    ldr x2, [x3], #8
-    ldr x2, [x2]
-    sub x4, x4, #1
+    cbz  x4, loaded_params
+    ldrb w6, [x5], #1
+    bl   load_param_by_size
+    mov  x2, x8
+    add  x3, x3, x6
+    sub  x4, x4, #1
+    b    loaded_params
 
-    // Clean
+load_param_by_size:
+    neg  x7, x6, lsl #3 // Get number of bits to throw away (0 - x6 * 8)
+    ldr  x8, [x3]       // Load next 64 bits of argument
+    lsl  x8, x8, x7     // Shift left to remove unneeded upper bits,
+                        // shifting in 0s on the right
+    lsr  x8, x8, x7     // Shift back right, again shifting in 0s on the left
+    ret
+
 loaded_params:
+    // Clean
     mov x3, xzr
     mov x4, xzr
     mov x5, xzr

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -48,7 +48,6 @@ function(new_test test_name)
     elseif(${ARGC} GREATER_EQUAL "3")
         set(test_bin ${ARGV1})
         list(JOIN ARGV2 " " test_args)
-        message(STATUS ${test_args})
         get_property(is_comp TARGET ${test_bin} PROPERTY compartment SET)
         if(is_comp)
             add_test(NAME ${test_name}
@@ -63,7 +62,9 @@ endfunction()
 
 # Library tests
 set(func_binaries
-    "test_map")
+    "test_map"
+    "test_args_near_unmapped"
+    )
 
 set(comp_binaries
     "simple"
@@ -74,7 +75,6 @@ set(comp_binaries
     )
 
 set(tests
-    "test_map"
     "simple"
     "time"
     "lua_simple"
@@ -86,6 +86,9 @@ set(tests
     "args-long-max args_simple check_llong_max 9223372036854775807"
     "args-long-min args_simple check_llong_min -9223372036854775808"
     "args-ulong-max args_simple check_ullong_max 18446744073709551615"
+    # Order matters, as these depend on some files to be copied in earlier tests
+    "test_map"
+    "test_args_near_unmapped"
     )
 
 foreach(comp_t IN LISTS comp_binaries)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -3,58 +3,108 @@
 add_executable(manager_call
     ${TEST_DIR}/manager_caller.c
     )
-target_include_directories(manager_call PUBLIC ${INCLUDE_DIR})
+target_include_directories(manager_call PUBLIC ${INCLUDE_DIR} ${TOML_INCLUDE_DIR})
 target_link_libraries(manager_call PUBLIC chcomp)
 
 add_executable(manager_args
     ${TEST_DIR}/manager_arg_passer.c
     )
-target_include_directories(manager_args PUBLIC ${INCLUDE_DIR})
+target_include_directories(manager_args PUBLIC ${INCLUDE_DIR} ${TOML_INCLUDE_DIR})
 target_link_libraries(manager_args PUBLIC chcomp)
 
 # Library test functions
 
-function(new_proj_test test_name compartment)
-    string(FIND ${test_name} " " test_name_delim_pos)
-    if (NOT ${test_name_delim_pos} EQUAL "-1")
-        string(SUBSTRING ${test_name} ${test_name_delim_pos} "-1" test_args)
-        string(STRIP ${test_args} test_args)
-        string(SUBSTRING ${test_name} "0" ${test_name_delim_pos} test_name)
-    endif()
+define_property(TARGET
+                PROPERTY compartment
+                BRIEF_DOCS "Whether this target is a CHERI compartment"
+                FULL_DOCS "Whether this target is a CHERI compartment")
+
+function(new_target test_name compartment)
     add_executable(${test_name}
         ${test_name}.c)
-    target_link_libraries(${test_name} PRIVATE chcomp lualib dl m)
+    target_link_libraries(${test_name} PRIVATE chcomp dl m)
+    target_link_libraries(${test_name} PRIVATE lualib)
     target_include_directories(${test_name} PRIVATE ${INCLUDE_DIR} ${LUA_INCLUDE_DIR})
     if(${compartment})
         target_compile_options(${test_name} PRIVATE -static)
         target_link_options(${test_name} PRIVATE -static "LINKER:-image-base=0x1000000")
-        add_test(NAME ${test_name}
-                 COMMAND ${CMAKE_SOURCE_DIR}/tests/run_test.sh comp $<TARGET_FILE:${test_name}> ${test_args})
+        set_property(TARGET ${test_name} PROPERTY compartment TRUE)
     else()
-        add_test(NAME ${test_name}
-                 COMMAND ${CMAKE_SOURCE_DIR}/tests/run_test.sh test $<TARGET_FILE:${test_name}>)
+        target_link_libraries(${test_name} PRIVATE tomllib)
+        target_include_directories(${test_name} PRIVATE ${TOML_INCLUDE_DIR})
+    endif()
+endfunction()
+
+function(new_test test_name)
+    if(${ARGC} EQUAL "1")
+        get_property(is_comp TARGET ${test_name} PROPERTY compartment SET)
+        if(is_comp)
+            add_test(NAME ${test_name}
+                     COMMAND ${CMAKE_SOURCE_DIR}/tests/run_test.sh comp $<TARGET_FILE:${test_name}>)
+        else()
+            add_test(NAME ${test_name}
+                     COMMAND ${CMAKE_SOURCE_DIR}/tests/run_test.sh test $<TARGET_FILE:${test_name}>)
+        endif()
+    elseif(${ARGC} GREATER_EQUAL "3")
+        set(test_bin ${ARGV1})
+        list(JOIN ARGV2 " " test_args)
+        message(STATUS ${test_args})
+        get_property(is_comp TARGET ${test_bin} PROPERTY compartment SET)
+        if(is_comp)
+            add_test(NAME ${test_name}
+                COMMAND ${CMAKE_SOURCE_DIR}/tests/run_test.sh comp $<TARGET_FILE:${test_bin}> ${test_args})
+        else()
+            message(FATAL_ERROR "Shouldn't get here")
+        endif()
+    else()
+        message(FATAL_ERROR "Missing arguments to test.")
     endif()
 endfunction()
 
 # Library tests
-set(func_tests
-    "test_map"
-    )
+set(func_binaries
+    "test_map")
 
-set(comp_tests
+set(comp_binaries
     "simple"
     "time"
     "lua_simple"
     "lua_script"
-    "args_simple 40 2"
-    "args_combined 400 20 0.69"
-    "args_long_max 42"
+    "args_simple"
     )
 
-foreach(comp_t IN LISTS comp_tests)
-    new_proj_test(${comp_t} TRUE)
+set(tests
+    "test_map"
+    "simple"
+    "time"
+    "lua_simple"
+    "lua_script"
+    "args-simple args_simple check_simple 40 2"
+    "args-more args_simple check_simple 40 2 2 2" # Check additional arguments are ignored
+    "args-combined args_simple check_combined 400 2 20"
+    "args-negative args_simple check_negative -42"
+    "args-long-max args_simple check_llong_max 9223372036854775807"
+    "args-long-min args_simple check_llong_min -9223372036854775808"
+    "args-ulong-max args_simple check_ullong_max 18446744073709551615"
+    )
+
+foreach(comp_t IN LISTS comp_binaries)
+    new_target(${comp_t} TRUE)
 endforeach()
 
-foreach(func_t IN LISTS func_tests)
-    new_proj_test(${func_t} FALSE)
+foreach(func_t IN LISTS func_binaries)
+    new_target(${func_t} FALSE)
+endforeach()
+
+foreach(test_t IN LISTS tests)
+    string(REPLACE " " ";" test_t_list ${test_t})
+    list(LENGTH test_t_list test_t_len)
+    if(${test_t_len} EQUAL "1")
+        new_test(${test_t})
+    else()
+        list(GET test_t_list 0 test_name)
+        list(GET test_t_list 1 test_bin)
+        list(SUBLIST test_t_list 2 -1 test_args)
+        new_test(${test_name} ${test_bin} "${test_args}")
+    endif()
 endforeach()

--- a/tests/args_simple.c
+++ b/tests/args_simple.c
@@ -1,10 +1,47 @@
 #include <assert.h>
 #include <stdlib.h>
+#include <limits.h>
 
 int
-check_fn(int one, int two)
+check_combined(int one, char two, long three)
+{
+    assert(400 + ('2' - '0') + (double) 0.69 == 402.69);
+    assert(one + (two - '0') + three == 422);
+    return 0;
+}
+
+int
+check_simple(int one, int two)
 {
     assert(one + two == 42);
+    return 0;
+}
+
+int
+check_negative(int one)
+{
+    assert(one == -42);
+    return 0;
+}
+
+int
+check_llong_max(long long one)
+{
+    assert(one == LLONG_MAX);
+    return 0;
+}
+
+int
+check_llong_min(long long one)
+{
+    assert(one == LLONG_MIN);
+    return 0;
+}
+
+int
+check_ullong_max(unsigned long long one)
+{
+    assert(one == ULLONG_MAX);
     return 0;
 }
 

--- a/tests/args_simple.comp
+++ b/tests/args_simple.comp
@@ -1,0 +1,23 @@
+[check_simple]
+args_count = 2
+args_type = ["int", "int"]
+
+[check_combined]
+args_count = 3
+args_type = ["int", "char", "long"]
+
+[check_negative]
+args_count = 1
+args_type = ["int"]
+
+[check_llong_max]
+args_count = 1
+args_type = ["long long"]
+
+[check_llong_min]
+args_count = 1
+args_type = ["long long"]
+
+[check_ullong_max]
+args_count = 1
+args_type = ["unsigned long long"]

--- a/tests/manager_caller.c
+++ b/tests/manager_caller.c
@@ -27,7 +27,7 @@ main(int argc, char** argv)
     comp_map(hw_comp);
     int comp_result;
     size_t comp_args_count = 0;
-    comp_result = comp_exec(hw_comp, "main", NULL, 0, NULL);
+    comp_result = comp_exec(hw_comp, "main", NULL, 0);
     comp_clean(hw_comp);
     free(main_cep);
     return comp_result;

--- a/tests/manager_caller.c
+++ b/tests/manager_caller.c
@@ -2,35 +2,6 @@
 
 extern struct Compartment* loaded_comp;
 
-struct CompEntryPoints
-{
-    char* file_name;
-    char** entry_points;
-    char** args;
-};
-
-// TODO
-#define comp_entries_count 1
-struct CompEntryPoints comp_entries[comp_entries_count] =
-{
-    "lua_script", (char*[]) { "do_script" }, NULL,
-};
-
-struct CompEntryPoints default_comp = { "default", (char*[]) {"main"}, NULL };
-
-struct CompEntryPoints*
-get_entry_points(char* comp_name)
-{
-    for (size_t i = 0; i < comp_entries_count; ++i)
-    {
-        if (!strcmp(comp_entries[i].file_name, comp_name))
-        {
-            return &comp_entries[i];
-        }
-    }
-    return &default_comp;
-}
-
 int
 main(int argc, char** argv)
 {
@@ -45,18 +16,19 @@ main(int argc, char** argv)
     {
         file += strlen(prefix);
     }
-    struct CompEntryPoints* file_entry_points = get_entry_points(file);
-    struct Compartment* hw_comp = comp_from_elf(file, file_entry_points->entry_points);
+
+    // Set default entry point with no arguments to pass
+    struct ConfigEntryPoint* main_cep = malloc(sizeof(struct ConfigEntryPoint));
+    main_cep = set_default_entry_point(main_cep);
+
+    struct Compartment* hw_comp = comp_from_elf(file, main_cep, 1);
     loaded_comp = hw_comp; // TODO
     log_new_comp(hw_comp);
     comp_map(hw_comp);
     int comp_result;
     size_t comp_args_count = 0;
-    if (file_entry_points->args)
-    {
-        comp_args_count = sizeof(file_entry_points->args) / sizeof(file_entry_points->args[0]);
-    }
-    comp_result = comp_exec(hw_comp, file_entry_points->entry_points[0], (void**) file_entry_points->args, comp_args_count);
+    comp_result = comp_exec(hw_comp, "main", NULL, 0, NULL);
     comp_clean(hw_comp);
+    free(main_cep);
     return comp_result;
 }

--- a/tests/run_test.sh
+++ b/tests/run_test.sh
@@ -30,7 +30,7 @@ then
     ssh -o "StrictHostKeyChecking no" -p $CHERIBSD_PORT $CHERIBSD_USER@$CHERIBSD_HOST -t "cd ${CHERIBSD_TEST_DIR} && ./$(basename "$test_name")"
 elif [ "$1" == "prep" ]
 then
-    FILES_TO_PREP=(./tests/manager_call ./tests/manager_args ../tests/hello_world.lua)
+    FILES_TO_PREP=(./tests/manager_call ./tests/manager_args ../tests/hello_world.lua ../tests/args_simple.comp)
     ssh -o "StrictHostKeyChecking no" -p $CHERIBSD_PORT $CHERIBSD_USER@$CHERIBSD_HOST -t "mkdir -p ${CHERIBSD_TEST_DIR}"
     scp -o "StrictHostKeyChecking no" -P $CHERIBSD_PORT "${FILES_TO_PREP[@]}" $CHERIBSD_USER@$CHERIBSD_HOST:${CHERIBSD_TEST_DIR}/
 else

--- a/tests/simple_arg.comp
+++ b/tests/simple_arg.comp
@@ -1,0 +1,2 @@
+check_simple,2,int,int
+check_combined,3,int,char,long

--- a/tests/test_map.c
+++ b/tests/test_map.c
@@ -7,9 +7,15 @@ main(int argc, char** argv)
     setup_intercepts();
 
     char* file = "./simple";
-    struct Compartment* hw_comp = comp_from_elf(file, NULL);
+
+    // Set default entry point with no arguments to pass
+    struct ConfigEntryPoint* main_cep = malloc(sizeof(struct ConfigEntryPoint));
+    main_cep = set_default_entry_point(main_cep);
+
+    struct Compartment* hw_comp = comp_from_elf(file, main_cep, 1);
     log_new_comp(hw_comp);
     comp_map(hw_comp);
     comp_clean(hw_comp);
+    free(main_cep);
     return 0;
 }

--- a/third-party/tomlc99.patch
+++ b/third-party/tomlc99.patch
@@ -1,5 +1,5 @@
 diff --git a/Makefile b/Makefile
-index 599f7db..16c81ea 100644
+index 599f7db..05b3956 100644
 --- a/Makefile
 +++ b/Makefile
 @@ -5,7 +5,8 @@ OBJ = $(CFILES:.c=.o)
@@ -8,7 +8,20 @@ index 599f7db..16c81ea 100644
  
 -CFLAGS = -std=c99 -Wall -Wextra -fpic
 +CFLAGS = --config cheribsd-morello-hybrid.cfg -std=c99 -Wall -Wextra -fpic
-+LDFLAGS = --config cheribdf-morello-hybrid.cfg
++LDFLAGS = --config cheribsd-morello-hybrid.cfg
  LIB_VERSION = 1.0
  LIB = libtoml.a
  LIB_SHARED = libtoml.so.$(LIB_VERSION)
+@@ -24,10 +25,10 @@ all: $(LIB) $(LIB_SHARED) $(EXEC)
+ *.o: $(HFILES)
+ 
+ libtoml.a: toml.o
+-	ar -rcs $@ $^
++	$(AR) -rcs $@ $^
+ 
+ libtoml.so.$(LIB_VERSION): toml.o
+-	$(CC) -shared -o $@ $^
++	$(CC) $(LDFLAGS) -shared -o $@ $^
+ 
+ $(EXEC): $(LIB)
+ 

--- a/third-party/tomlc99.patch
+++ b/third-party/tomlc99.patch
@@ -1,0 +1,14 @@
+diff --git a/Makefile b/Makefile
+index 599f7db..16c81ea 100644
+--- a/Makefile
++++ b/Makefile
+@@ -5,7 +5,8 @@ OBJ = $(CFILES:.c=.o)
+ EXEC = toml_json toml_cat toml_sample
+ PCFILE = libtoml.pc
+ 
+-CFLAGS = -std=c99 -Wall -Wextra -fpic
++CFLAGS = --config cheribsd-morello-hybrid.cfg -std=c99 -Wall -Wextra -fpic
++LDFLAGS = --config cheribdf-morello-hybrid.cfg
+ LIB_VERSION = 1.0
+ LIB = libtoml.a
+ LIB_SHARED = libtoml.so.$(LIB_VERSION)


### PR DESCRIPTION
Now can specify compartment entry points via a `toml` file of the name `<binary>.comp`, where `<binary>` is the name of the ELF binary to be compartmentalize, and the associated configuration file should reside in the same folder as the compartment binary.

The format of the `toml` file is:
* each entry point is defined as a `toml` table, with the table name being the entry function name in the compartment binary;
* entry `args_count` is of type number, and says how many arguments we expect to pass to the entry function;
* entry `args_type` is an array and enumerates the types to be passed to the function.

This comes with additional internal functionality to convert between types (the conversion is done manually, i.e., new types need to be added to the code, rather than being dynamically handled).

Additional tests added, and reworked how tests in CMake are done, to better handle argument support.