### PR TITLE
First inter-compartment call implementation

### DIFF
--- a/include/manager.h
+++ b/include/manager.h
@@ -56,22 +56,26 @@ void* my_malloc(size_t);
 void my_free(void*);
 int my_fprintf(FILE*, const char*, ...);
 
+size_t my_call_comp(size_t, char*, void*, size_t);
+
 static const struct func_intercept to_intercept_funcs[] = {
     /* vDSO funcs */
-    { "time"    , (uintptr_t) manager_time    },
+    { "time"     , (uintptr_t) manager_time    },
     /* Mem funcs */
-    { "malloc"  , (uintptr_t) my_malloc       },
-    { "realloc" , (uintptr_t) my_realloc      },
-    { "free"    , (uintptr_t) my_free         },
-    { "fprintf" , (uintptr_t) my_fprintf      },
+    { "malloc"   , (uintptr_t) my_malloc       },
+    { "realloc"  , (uintptr_t) my_realloc      },
+    { "free"     , (uintptr_t) my_free         },
+    { "fprintf"  , (uintptr_t) my_fprintf      },
+    /* Compartment funcs */
+    { "call_comp", (uintptr_t) my_call_comp    },
     /* Other funcs */
-    { "fopen"   , (uintptr_t) manager_fopen   },
-    { "fread"   , (uintptr_t) manager_fread   },
-    { "fwrite"  , (uintptr_t) manager_fwrite  },
-    { "fclose"  , (uintptr_t) manager_fclose  },
-    { "getc"    , (uintptr_t) manager_getc    },
-    { "fputc"   , (uintptr_t) manager_fputc   },
-    { "__srget" , (uintptr_t) manager___srget },
+    { "fopen"    , (uintptr_t) manager_fopen   },
+    { "fread"    , (uintptr_t) manager_fread   },
+    { "fwrite"   , (uintptr_t) manager_fwrite  },
+    { "fclose"   , (uintptr_t) manager_fclose  },
+    { "getc"     , (uintptr_t) manager_getc    },
+    { "fputc"    , (uintptr_t) manager_fputc   },
+    { "__srget"  , (uintptr_t) manager___srget },
 };
 //
 // Functions to be intercepted and associated data
@@ -100,6 +104,7 @@ extern void* __capability comp_return_caps[COMP_RETURN_CAPS_COUNT];
 
 struct Compartment* manager_find_compartment_by_addr(void*);
 struct Compartment* manager_find_compartment_by_ddc(void* __capability);
+struct Compartment* manager_get_compartment_by_id(size_t);
 
 #include "compartment.h"
 
@@ -121,7 +126,8 @@ union arg_holder
     unsigned long long ull;
 };
 
-struct ConfigEntryPoint* parse_compartment_config(FILE*, size_t*);
+char* prep_config_filename(char*);
+struct ConfigEntryPoint* parse_compartment_config(char*, size_t*);
 void clean_compartment_config(struct ConfigEntryPoint*, size_t);
 struct ConfigEntryPoint get_entry_point(char*, struct ConfigEntryPoint*, size_t);
 void* prepare_compartment_args(char** args, struct ConfigEntryPoint);

--- a/src/transition.S
+++ b/src/transition.S
@@ -38,7 +38,22 @@ compartment_transition_out_end:
 .global comp_exec_in
 .type comp_exec_in, "function"
 comp_exec_in:
-    stp lr, x29, [sp, #-16]!
+    /* Store data required to be restored later
+    /  - `x19` is callee-saved, used to hold the stack pointer between
+         `comp_exec_in` and `comp_exec_out`
+       - `lr` is used to remember where we came from, so we can return
+       - `x29` is used for TODO???
+
+       Stack layout:
+       `SP + 5 * 8` -->  ------------------
+       `SP + 4 * 8` --> |    < PADDING >   |
+       `SP + 3 * 8`   > |      old x29     |
+       `SP + 2 * 8`   > |      old LR      |
+       `SP + 1 * 8`   > | callee-saved x19 |
+       `    new SP`   >  ------------------
+    */
+    stp x19, lr, [sp, #-32]!
+    str x29, [sp, #16]
     mov x19, sp
 
     // Move arguments to temporary registers (we'll need them later)
@@ -85,11 +100,15 @@ loaded_params:
  *
  * Expects `DDC` in c29, resets `sp` and `clr` to continue execution for the
  * manager. The result of the compartment is expected in `x0`.
+ *
+ * This function should only be called from `comp_exec_in`, after the
+ * compartment has finished executing.
  */
 .global comp_exec_out
 .type comp_exec_out, "function"
 comp_exec_out:
     msr DDC, c29
     mov sp, x19
-    ldp lr, x29, [sp], #16
+    ldp x19, lr, [sp], #32
+    ldr x29, [sp, #-16]
     ret

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -52,7 +52,11 @@ function(new_target test_name compartment)
     target_include_directories(${test_name} PRIVATE ${INCLUDE_DIR} ${LUA_INCLUDE_DIR})
     if(${compartment})
         target_compile_options(${test_name} PRIVATE -static)
-        target_link_options(${test_name} PRIVATE -static "LINKER:-image-base=0x1000000")
+        if(${ARGC} GREATER 2)
+            target_link_options(${test_name} PRIVATE -static "LINKER:-image-base=${ARGV2}")
+        else()
+            target_link_options(${test_name} PRIVATE -static "LINKER:-image-base=0x1000000")
+        endif()
         set_property(TARGET ${test_name} PROPERTY compartment TRUE)
         if (EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/${test_name}.comp)
             set_property(TARGET ${test_name} PROPERTY compartment_config ${CMAKE_CURRENT_SOURCE_DIR}/${test_name}.comp)
@@ -105,24 +109,12 @@ function(new_dependency target dep_file)
     set_property(TARGET ${target} APPEND PROPERTY extra_deps ${dep_file})
 endfunction()
 
-function(two_comp_test test_bin comp1 comp2)
-    add_executable(${test_bin} ${test_bin}.c)
-    target_link_libraries(${test_bin} PRIVATE chcomp dl m lualib)
-    target_include_directories(${test_bin} PRIVATE ${INCLUDE_DIR} ${LUA_INCLUDE_DIR} ${TOML_INCLUDE_DIR})
-    add_executable(${comp1} ${comp1}.c)
-    target_compile_options(${comp1} PRIVATE -static)
-    target_link_options(${comp1} PRIVATE -static "LINKER:-image-base=0x1000000")
-    add_executable(${comp2} ${comp2}.c)
-    target_compile_options(${comp2} PRIVATE -static)
-    target_link_options(${comp2} PRIVATE -static "LINKER:-image-base=0x2000000")
-    add_test(NAME test_two_comp-${test_bin}
-        COMMAND ${CMAKE_SOURCE_DIR}/tests/run_test.py $<TARGET_FILE:${test_bin}> --dependencies $<TARGET_FILE:${comp1}> $<TARGET_FILE:${comp2}>)
-endfunction()
-
 # Library tests
 set(func_binaries
     "test_map"
     "test_args_near_unmapped"
+    "test_two_comps"
+    "test_two_comps_inter_call"
     )
 
 set(comp_binaries
@@ -131,6 +123,8 @@ set(comp_binaries
     "lua_simple"
     "lua_script"
     "args_simple"
+    "test_two_comps-comp1"
+    "test_two_comps-comp2 0x2000000"
     )
 
 set(tests
@@ -140,6 +134,8 @@ set(tests
     "lua_script"
     "test_map"
     "test_args_near_unmapped"
+    "test_two_comps"
+    "test_two_comps_inter_call"
     "args-simple args_simple check_simple 40 2"
     "args-more args_simple check_simple 40 2 2 2" # Check additional arguments are ignored
     "args-combined args_simple check_combined 400 2 20"
@@ -149,11 +145,18 @@ set(tests
     "args-ulong-max args_simple check_ullong_max 18446744073709551615"
     )
 
-#two_comp_test(test_two_comps test_two_comps-comp1 test_two_comps-comp2)
 
 # Build targets
 foreach(comp_t IN LISTS comp_binaries)
-    new_target(${comp_t} TRUE)
+    string(FIND ${comp_t} " " space_pos)
+    if(${space_pos} EQUAL -1)
+        new_target(${comp_t} TRUE)
+    else()
+        string(SUBSTRING ${comp_t} 0 ${space_pos} tgt_name)
+        string(SUBSTRING ${comp_t} ${space_pos} -1 img_base)
+        string(STRIP ${img_base} img_base)
+        new_target(${tgt_name} TRUE ${img_base})
+    endif()
 endforeach()
 
 foreach(func_t IN LISTS func_binaries)
@@ -164,6 +167,14 @@ endforeach()
 new_dependency(lua_script ${CMAKE_CURRENT_SOURCE_DIR}/hello_world.lua)
 new_dependency(test_args_near_unmapped $<TARGET_FILE:args_simple>)
 new_dependency(test_args_near_unmapped ${CMAKE_CURRENT_SOURCE_DIR}/args_simple.comp)
+
+new_dependency(test_two_comps $<TARGET_FILE:test_two_comps-comp1>)
+new_dependency(test_two_comps $<TARGET_FILE:test_two_comps-comp2>)
+new_dependency(test_two_comps ${CMAKE_CURRENT_SOURCE_DIR}/test_two_comps-comp1.comp)
+
+new_dependency(test_two_comps_inter_call $<TARGET_FILE:test_two_comps-comp1>)
+new_dependency(test_two_comps_inter_call $<TARGET_FILE:test_two_comps-comp2>)
+new_dependency(test_two_comps_inter_call ${CMAKE_CURRENT_SOURCE_DIR}/test_two_comps-comp1.comp)
 
 # Prepare tests
 foreach(test_t IN LISTS tests)

--- a/tests/args_simple.comp
+++ b/tests/args_simple.comp
@@ -1,23 +1,17 @@
 [check_simple]
-args_count = 2
 args_type = ["int", "int"]
 
 [check_combined]
-args_count = 3
 args_type = ["int", "char", "long"]
 
 [check_negative]
-args_count = 1
 args_type = ["int"]
 
 [check_llong_max]
-args_count = 1
 args_type = ["long long"]
 
 [check_llong_min]
-args_count = 1
 args_type = ["long long"]
 
 [check_ullong_max]
-args_count = 1
 args_type = ["unsigned long long"]

--- a/tests/test_args_near_unmapped.c
+++ b/tests/test_args_near_unmapped.c
@@ -20,20 +20,13 @@ main(int argc, char** argv)
     setup_intercepts();
 
     char* file = "args_simple";
-    char* file_config = malloc(sizeof(file) + sizeof(comp_config_suffix) + 1);
-    strcpy(file_config, file);
-    strcat(file_config, comp_config_suffix);
-    FILE* comp_config_fd = fopen(file_config, "r");
-    free(file_config);
-    struct ConfigEntryPoint* cep = NULL;
     size_t entry_point_count = 0;
-    char** entry_points = NULL;
-    if (comp_config_fd)
+    struct ConfigEntryPoint* cep = parse_compartment_config(file, &entry_point_count);
+    if (!cep)
     {
-        cep = parse_compartment_config(comp_config_fd, &entry_point_count);
-        fclose(comp_config_fd);
+        cep = malloc(sizeof(struct ConfigEntryPoint));
+        cep = set_default_entry_point(cep);
     }
-    // TODO else set main as default entry point
 
     struct Compartment* arg_comp = comp_from_elf(file, cep, entry_point_count);
     loaded_comp = arg_comp; // TODO

--- a/tests/test_two_comps-comp1.c
+++ b/tests/test_two_comps-comp1.c
@@ -1,0 +1,17 @@
+#include <stdio.h>
+
+size_t call_comp(size_t comp_id, char* fn_name, void* args, size_t arg_count) { return 0; };
+
+int
+inter_call()
+{
+    size_t call_res = call_comp(1, "main", NULL, 0);
+    return 0;
+}
+
+int
+main()
+{
+    fprintf(stdout, "Hello, I am comp1.\n");
+    return 0;
+}

--- a/tests/test_two_comps-comp1.comp
+++ b/tests/test_two_comps-comp1.comp
@@ -1,0 +1,2 @@
+[inter_call]
+args_type = []

--- a/tests/test_two_comps-comp2.c
+++ b/tests/test_two_comps-comp2.c
@@ -1,0 +1,8 @@
+#include <stdio.h>
+
+int
+main()
+{
+    fprintf(stdout, "Hello, I am comp2.\n");
+    return 0;
+}

--- a/tests/test_two_comps.c
+++ b/tests/test_two_comps.c
@@ -1,0 +1,46 @@
+#include "manager.h"
+
+extern struct Compartment* loaded_comp;
+
+int
+main(int argc, char** argv)
+{
+    // Initial setup
+    manager_ddc = cheri_ddc_get();
+    setup_intercepts();
+
+    char* comp_file_1 = "test_two_comps-comp1";
+    char* comp_file_2 = "test_two_comps-comp2";
+
+    // Set default entry point with no arguments to pass
+    // Used for both compartments
+    struct ConfigEntryPoint* main_cep = malloc(sizeof(struct ConfigEntryPoint));
+    main_cep = set_default_entry_point(main_cep);
+
+    // Load comp1
+    struct Compartment* comp1 = comp_from_elf(comp_file_1, main_cep, 1);
+    log_new_comp(comp1);
+    comp_map(comp1);
+    fprintf(stdout, "Mapped Comp 1\n");
+
+    // Load comp2
+    struct Compartment* comp2 = comp_from_elf(comp_file_2, main_cep, 1);
+    log_new_comp(comp2);
+    comp_map(comp2);
+    fprintf(stdout, "Mapped Comp 2\n");
+
+    int comp_result;
+
+    // Run Comp 1
+    loaded_comp = comp1;
+    comp_result = comp_exec(comp1, "main", NULL, 0);
+    comp_clean(comp1);
+
+    // Run Comp 2
+    loaded_comp = comp2;
+    comp_result |= comp_exec(comp2, "main", NULL, 0);
+    comp_clean(comp2);
+
+    free(main_cep);
+    return comp_result;
+}

--- a/tests/test_two_comps_inter_call.c
+++ b/tests/test_two_comps_inter_call.c
@@ -1,0 +1,43 @@
+#include "manager.h"
+
+extern struct Compartment* loaded_comp;
+
+int
+main(int argc, char** argv)
+{
+    // Initial setup
+    manager_ddc = cheri_ddc_get();
+    setup_intercepts();
+
+    char* comp_file_1 = "test_two_comps-comp1";
+    char* comp_file_2 = "test_two_comps-comp2";
+
+    // Read entry point data for compartment 1
+    size_t ep_count = 0;
+    struct ConfigEntryPoint* comp1_cep = parse_compartment_config(comp_file_1, &ep_count);
+    struct ConfigEntryPoint* main_cep = malloc(sizeof(struct ConfigEntryPoint));
+    main_cep = set_default_entry_point(main_cep);
+
+    // Load comp1
+    struct Compartment* comp1 = comp_from_elf(comp_file_1, comp1_cep, 1);
+    log_new_comp(comp1);
+    comp_map(comp1);
+    fprintf(stdout, "Mapped Comp 1\n");
+
+    // Load comp2
+    struct Compartment* comp2 = comp_from_elf(comp_file_2, main_cep, 1);
+    log_new_comp(comp2);
+    comp_map(comp2);
+    fprintf(stdout, "Mapped Comp 2\n");
+
+
+    // Run Comp 1
+    loaded_comp = comp1;
+    int comp_result = comp_exec(comp1, "inter_call", NULL, 0);
+    assert(comp_result == 0);
+    comp_clean(comp1);
+    comp_clean(comp2);
+
+    free(comp1_cep);
+    return comp_result;
+}


### PR DESCRIPTION
Main feature is two new added tests, `test_two_comps` and `test_two_comps_inter_call`. The former loads and maps two compartments in memory, then consecutively calls a function in each of them, while the latter loads and maps two compartments in memory, calling a function in the first one, which itself calls a function in the second one.

Additionally move more configuration file-related functionality in the library: now we only need the binary (i.e., compartment) file name, and we then derive the filename and load the configuration information.

During this, I stumbled across a number of TODOs (and added some more related to questionable code). I think the scope of this PR is sufficient as is (as it is a rather major feature by itself, even if limited in code changes), and plan on addressing some of these TODOs in the next step; I am happy to fold maybe at least some of them, directly related to multiple compartment support, in this PR, if we think that is better.