### PR TITLE
Add a new test

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,10 @@
 cmake_minimum_required(VERSION 3.16)
 project(CHERI_ELF_Compartments LANGUAGES C ASM)
 
+# Set global compilation options
+set(CMAKE_COMPILE_WARNING_AS_ERROR ON)
+
+# Set useful directory variables
 set(TEST_DIR ${CMAKE_SOURCE_DIR}/tests)
 set(SRC_DIR ${CMAKE_SOURCE_DIR}/src)
 set(INCLUDE_DIR ${CMAKE_SOURCE_DIR}/include)

--- a/src/compartment.c
+++ b/src/compartment.c
@@ -58,13 +58,20 @@ comp_from_elf(char* filename, struct ConfigEntryPoint* entry_points, size_t entr
     struct Compartment* new_comp = comp_init();
     int pread_res;
 
+    new_comp->fd = open(filename, O_RDONLY);
+    if (new_comp->fd == -1)
+    {
+        printf("Error opening compartment file  %s!\n", filename);
+        free(new_comp);
+        exit(1);
+    }
+
     assert(entry_points);
     assert(entry_point_count > 0);
     new_comp->comp_fns = malloc(entry_point_count * sizeof(struct entry_point));
 
     // Read elf headers
     Elf64_Ehdr comp_ehdr;
-    new_comp->fd = open(filename, O_RDONLY);
     assert(new_comp->fd != -1);
     pread_res = pread(new_comp->fd, &comp_ehdr, sizeof(comp_ehdr), 0);
     assert(pread_res != -1);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -28,7 +28,7 @@ define_property(TARGET
                 FULL_DOCS "Additional file dependencies to run a test.")
 
 # Helper functions
-function(get_deps target deps_var)
+function(get_deps target)
     set(deps_var "")
     list(APPEND deps_var $<TARGET_FILE:${target}>)
     get_property(has_config TARGET ${target} PROPERTY compartment_config SET)
@@ -67,52 +67,36 @@ function(new_target test_name compartment)
     endif()
 endfunction()
 
-function(new_test test_name)
-    if(${ARGC} EQUAL "1")
-        get_property(is_comp TARGET ${test_name} PROPERTY compartment SET)
-        get_deps(${test_name} deps_var)
-        if(is_comp)
-            add_test(NAME ${test_name}
-                     COMMAND ${CMAKE_SOURCE_DIR}/tests/run_test.py
-                             manager_call
-                             --test-args $<TARGET_FILE_NAME:${test_name}>
-                             --dependencies ${deps_var}
-                     COMMAND_EXPAND_LISTS)
-        else()
-            add_test(NAME ${test_name}
-                     COMMAND ${CMAKE_SOURCE_DIR}/tests/run_test.py
-                             $<TARGET_FILE_NAME:${test_name}>
-                             --dependencies ${deps_var}
-                     COMMAND_EXPAND_LISTS)
-        endif()
-    elseif(${ARGC} GREATER_EQUAL "3")
-        set(test_bin ${ARGV1})
-        list(JOIN ARGV2 " " test_args)
-        get_property(is_comp TARGET ${test_bin} PROPERTY compartment SET)
-        get_deps(${test_bin} deps_var)
-        if(is_comp)
-            add_test(NAME ${test_name}
-                COMMAND ${CMAKE_SOURCE_DIR}/tests/run_test.py
-                        manager_args
-                        --test-args $<TARGET_FILE_NAME:${test_bin}> ${test_args}
-                        --dependencies ${deps_var}
-                COMMAND_EXPAND_LISTS)
-        else()
-            message(FATAL_ERROR "Shouldn't get here")
-        endif()
+function(new_test test_name test_runner test_bin)
+    if(test_bin)
+        get_deps(${test_bin})
     else()
-        message(FATAL_ERROR "Missing arguments to test.")
+        get_deps(${test_runner})
     endif()
+    list(PREPEND test_cmd ${deps_var})
+    if(test_cmd)
+        list(PREPEND test_cmd "--dependencies")
+    endif()
+    if(test_bin)
+        list(PREPEND test_cmd ${ARGN})
+        list(PREPEND test_cmd ${test_bin})
+        list(PREPEND test_cmd "--test-args")
+    endif()
+    list(PREPEND test_cmd $<TARGET_FILE_NAME:${test_runner}>)
+    add_test(NAME ${test_name}
+             COMMAND ${CMAKE_SOURCE_DIR}/tests/run_test.py ${test_cmd}
+             COMMAND_EXPAND_LISTS)
 endfunction()
 
 function(new_dependency target dep_file)
     set_property(TARGET ${target} APPEND PROPERTY extra_deps ${dep_file})
 endfunction()
 
-# Library tests
+# Binaries to build
 set(func_binaries
     "test_map"
     "test_args_near_unmapped"
+    "test_ddc_overwrite_manager"
     "test_two_comps"
     "test_two_comps_inter_call"
     )
@@ -123,30 +107,37 @@ set(comp_binaries
     "lua_simple"
     "lua_script"
     "args_simple"
+    "test_ddc_overwrite"
     "test_two_comps-comp1"
     "test_two_comps-comp2 0x2000000"
     )
 
-set(tests
-    "simple"
-    "time"
-    "lua_simple"
-    "lua_script"
+# Tests with no arguments
+set(tests_direct
     "test_map"
     "test_args_near_unmapped"
     "test_two_comps"
     "test_two_comps_inter_call"
-    "args-simple args_simple check_simple 40 2"
-    "args-more args_simple check_simple 40 2 2 2" # Check additional arguments are ignored
-    "args-combined args_simple check_combined 400 2 20"
-    "args-negative args_simple check_negative -42"
-    "args-long-max args_simple check_llong_max 9223372036854775807"
-    "args-long-min args_simple check_llong_min -9223372036854775808"
-    "args-ulong-max args_simple check_ullong_max 18446744073709551615"
+    "test_ddc_overwrite_manager"
     )
 
+# Tests with arguments
+# FORMAT : <test_name> <binary> <binary_args> [...]
+set(tests_args
+    "simple manager_call simple"
+    "time manager_call time"
+    "lua_simple manager_call lua_simple"
+    "lua_script manager_call lua_script"
+    "args-simple manager_args args_simple check_simple 40 2"
+    "args-more manager_args args_simple check_simple 40 2 2 2" # Check additional arguments are ignored
+    "args-combined manager_args args_simple check_combined 400 2 20"
+    "args-negative manager_args args_simple check_negative -42"
+    "args-long-max manager_args args_simple check_llong_max 9223372036854775807"
+    "args-long-min manager_args args_simple check_llong_min -9223372036854775808"
+    "args-ulong-max manager_args args_simple check_ullong_max 18446744073709551615"
+    )
 
-# Build targets
+#  Build targets
 foreach(comp_t IN LISTS comp_binaries)
     string(FIND ${comp_t} " " space_pos)
     if(${space_pos} EQUAL -1)
@@ -163,8 +154,9 @@ foreach(func_t IN LISTS func_binaries)
     new_target(${func_t} FALSE)
 endforeach()
 
+
 # Additional dependencies
-new_dependency(lua_script ${CMAKE_CURRENT_SOURCE_DIR}/hello_world.lua)
+new_dependency(test_map $<TARGET_FILE:simple>)
 new_dependency(test_args_near_unmapped $<TARGET_FILE:args_simple>)
 new_dependency(test_args_near_unmapped ${CMAKE_CURRENT_SOURCE_DIR}/args_simple.comp)
 
@@ -176,16 +168,24 @@ new_dependency(test_two_comps_inter_call $<TARGET_FILE:test_two_comps-comp1>)
 new_dependency(test_two_comps_inter_call $<TARGET_FILE:test_two_comps-comp2>)
 new_dependency(test_two_comps_inter_call ${CMAKE_CURRENT_SOURCE_DIR}/test_two_comps-comp1.comp)
 
+new_dependency(test_ddc_overwrite_manager $<TARGET_FILE:test_ddc_overwrite>)
+new_dependency(test_ddc_overwrite_manager ${CMAKE_CURRENT_SOURCE_DIR}/test_ddc_overwrite.comp)
+
+new_dependency(lua_script ${CMAKE_CURRENT_SOURCE_DIR}/hello_world.lua)
+
+foreach(test_d IN LISTS tests_direct)
+    new_test(${test_d} ${test_d} "" "")
+endforeach()
+
 # Prepare tests
-foreach(test_t IN LISTS tests)
-    string(REPLACE " " ";" test_t_list ${test_t})
-    list(LENGTH test_t_list test_t_len)
-    if(${test_t_len} EQUAL "1")
-        new_test(${test_t})
-    else()
-        list(GET test_t_list 0 test_name)
-        list(GET test_t_list 1 test_bin)
-        list(SUBLIST test_t_list 2 -1 test_args)
-        new_test(${test_name} ${test_bin} "${test_args}")
+foreach(test_a IN LISTS tests_args)
+    string(REPLACE " " ";" test_args_list ${test_a})
+    list(GET test_args_list 0 test_name)
+    list(GET test_args_list 1 test_runner)
+    list(GET test_args_list 2 test_bin)
+    list(LENGTH test_args_list test_args_len)
+    if(${test_args_len} GREATER 3)
+        list(SUBLIST test_args_list 3 -1 test_bin_args)
     endif()
+    new_test(${test_name} ${test_runner} ${test_bin} ${test_bin_args})
 endforeach()

--- a/tests/test_ddc_overwrite.c
+++ b/tests/test_ddc_overwrite.c
@@ -1,0 +1,37 @@
+#include <assert.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+#include "cheriintrin.h"
+
+/* This test attempts to circumvent the DDC compartmentalization feature by
+ * using the existing PCC as a temporary DDC to access a secret pointer beyond
+ * the original bounds of the compartment. The address of the secret is
+ * expected to be passed as `secret_addr`, and the function will return the
+ * value at that address. If the given `secret_addr` is out of the original DDC
+ * bounds, and this test does not fail, then we have broken the expected
+ * security guarantees of our DDC compartmentalization approach.
+ */
+
+int
+test_leak(unsigned long long secret_addr)
+{
+    int secret;
+    asm volatile("cvtp c0, %[addr]\n\t"
+                 "ldr %w[val], [c0]"
+            : [val] "=r"(secret)
+            : [addr] "r"(secret_addr)
+            : "x0", "memory");
+    return secret;
+}
+
+int
+main()
+{
+    int* secret = malloc(sizeof(int));
+    *secret = 42;
+    int val = test_leak((unsigned long long) secret);
+    assert(val == *secret);
+    free(secret);
+    return 0;
+}

--- a/tests/test_ddc_overwrite.comp
+++ b/tests/test_ddc_overwrite.comp
@@ -1,0 +1,2 @@
+[test_leak]
+args_type = ["unsigned long long"]

--- a/tests/test_ddc_overwrite_manager.c
+++ b/tests/test_ddc_overwrite_manager.c
@@ -1,0 +1,48 @@
+#include <limits.h>
+
+#include "manager.h"
+
+/* Test wrapper for compartments with arguments.
+ *
+ * Takes at least two arguments: one argument for the compartment binary name,
+ * and one argument minimum to be passed to the compartment itself.
+ * TODO currently hard coding the entry points and which entry point to call,
+ * but plan to move this to some configuration file in the near future
+ */
+
+extern struct Compartment* loaded_comp;
+
+int
+main(int argc, char** argv)
+{
+    // Initial setup
+    manager_ddc = cheri_ddc_get();
+    setup_intercepts();
+
+    char* file = "test_ddc_overwrite";
+    size_t entry_point_count = 0;
+    struct ConfigEntryPoint* cep = parse_compartment_config(file, &entry_point_count);
+    assert(cep);
+
+    struct Compartment* arg_comp = comp_from_elf(file, cep, entry_point_count);
+    log_new_comp(arg_comp);
+    comp_map(arg_comp);
+
+    int* secret = malloc(sizeof(int));
+    *secret = 42;
+
+    char* entry_func = "test_leak";
+    size_t secret_addr_str_len = snprintf(NULL, 0, "%llu", (unsigned long long) secret);
+    char* secret_addr_str = malloc(secret_addr_str_len + 1);
+    sprintf(secret_addr_str, "%llu", (unsigned long long) secret);
+    char* entry_func_args[1] = { secret_addr_str };
+    struct ConfigEntryPoint comp_entry = get_entry_point(entry_func, cep, entry_point_count);
+    void* comp_args = prepare_compartment_args(entry_func_args, comp_entry);
+
+    int comp_result = comp_exec(arg_comp, entry_func, comp_args, comp_entry.arg_count);
+    clean_compartment_config(cep, entry_point_count);
+    comp_clean(arg_comp);
+    assert(comp_result == *secret);
+    free(secret_addr_str);
+    return 0;
+}


### PR DESCRIPTION
* Simplify testing interfact in `tests` CMakeFile. Now it's easier to write how tests will be ran, without a bunch of in-built inference
* Add a test `ddc_overwrite`, which attempts to break the DDC compartmentalizatin approach by temporarily using the PCC as the DDC to access a secret