### PR TITLE
Initial support for `.so` compartments

### DIFF
--- a/.run_cheri_qemu_and_test.py
+++ b/.run_cheri_qemu_and_test.py
@@ -24,9 +24,12 @@ def run_tests(qemu: boot_cheribsd.QemuCheriBSDInstance, args: argparse.Namespace
         boot_cheribsd.set_ld_library_path_with_sysroot(qemu)
     boot_cheribsd.info("Running tests for CHERI-ELF-compartments")
 
+    # Test environment setup
+    subprocess.run(["./tests/init_test.py"], check = True)
+
     # Run command on host to test the executed client
     os.chdir(f"{args.build_dir}/build")
-    subprocess.run(["ctest", "--output-on-failure"], check=True)
+    subprocess.run(["ctest", "--output-on-failure"], check = True)
     return True
 
 if __name__ == '__main__':

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.16)
 project(CHERI_ELF_Compartments LANGUAGES C ASM)
 
 # Set global compilation options
-set(CMAKE_COMPILE_WARNING_AS_ERROR ON)
+add_compile_options(-pedantic -Wno-gnu-binary-literal -Wno-language-extension-token -Werror)
 
 # Set useful directory variables
 set(TEST_DIR ${CMAKE_SOURCE_DIR}/tests)
@@ -12,12 +12,12 @@ set(INCLUDE_DIR ${CMAKE_SOURCE_DIR}/include)
 # Build lua
 set(LUA_DIR ${CMAKE_SOURCE_DIR}/third-party/lua)
 set(LUA_INSTALL_DIR ${LUA_DIR})
-set(LUA_LIB_PATH ${LUA_DIR}/liblua.a)
+set(LUA_LIB_PATH ${LUA_DIR}/liblua.so)
 set(LUA_INCLUDE_DIR ${LUA_DIR})
 
 add_custom_command(
     OUTPUT ${LUA_LIB_PATH}
-    COMMAND make a
+    COMMAND make
     WORKING_DIRECTORY ${LUA_DIR}
 )
 

--- a/include/compartment.h
+++ b/include/compartment.h
@@ -3,8 +3,12 @@
 
 #include <assert.h>
 #include <elf.h>
+#include <err.h>
+#include <errno.h>
 #include <fcntl.h>
+#include <fts.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -14,8 +18,6 @@
 #include <unistd.h>
 
 #include "cheriintrin.h"
-
-#include "manager.h"
 
 // Morello `gcc` defines `ptraddr_t` in `stddef.h`, while `clang` does so in
 // `stdint.h`
@@ -27,17 +29,13 @@
 #define align_down(x, align)    __builtin_align_down(x, align)
 #define align_up(x, align)      __builtin_align_up(x, align)
 
-// Maximum number of allowed segments per loaded ELF file
-// TODO rethink number/make it a parameter
-#define SEG_MAX_COUNT 20
-
 // TODO once things stabilize, recheck if all struct members are required
 // currently there's quite a bit of redundancy to make things easier to think
 // about
 
-struct func_intercept;
 void compartment_transition_out();
-int64_t comp_exec_in(void*, void* __capability, void*, void*, size_t);
+int64_t comp_exec_in(void*, void* __capability, void*, void*, size_t,
+                     void* __capability);
 void comp_exec_out();
 
 // Declare built-in function for cache synchronization:
@@ -51,8 +49,14 @@ extern void __clear_cache(void*, void*);
 // Number of instructions required by the transition function
 #define COMP_TRANS_FN_INSTR_CNT 4
 
+extern void* __capability sealed_redirect_cap;
+extern void* __capability comp_return_caps[2];
+
 /* For a function to be intercepted, information required to insert the
  * redirect code and perform redirection
+ *
+ * TODO recheck this is properly used, or re-design into a more light-weight
+ * approach with pre-given transition capabilities
  */
 struct intercept_patch
 {
@@ -73,25 +77,12 @@ struct intercept_patch
 #error Expecting 64-bit Arm Morello platform
 #endif
 
-/* Struct representing configuration data for one entry point; this is just
- * information that we expect to appear in the compartment, as given by its
- * compartment configuration file
- */
-struct ConfigEntryPoint
-{
-    const char* name;
-    size_t arg_count;
-    char** args_type;
-};
-
 /* Struct representing a valid entry point to a compartment
  */
 struct entry_point
 {
     const char* fn_name;
-    uintptr_t fn_addr;
-    size_t arg_count;
-    char** arg_types;
+    void* fn_addr;
 };
 
 /* Struct representing one segment of an ELF binary.
@@ -99,13 +90,47 @@ struct entry_point
  * TODO expand */
 struct SegmentMap
 {
-    uintptr_t mem_bot;
-    uintptr_t mem_top;
+    void* mem_bot;
+    void* mem_top;
     size_t offset;
-    size_t correction;
+    ptrdiff_t correction;
     size_t mem_sz;
     size_t file_sz;
     int prot_flags;
+};
+
+/* Struct representing an eager relocation to be made at map-time - instead of
+ * lazily looking up function addresses once a function is called at runtime,
+ * via PLT/GOT, we update the expected addresses eagerly once the code is
+ * mapped into memory, via `comp_map`
+ */
+struct CompRelaMapping
+{
+    char* rela_name;
+    void* rela_address; // address of relocation in compartment
+    void* target_func_address; // address of actual function
+};
+
+/* Struct representing a symbol entry of a dependency library
+ */
+struct LibDependencySymbol
+{
+    char* sym_name;
+    intptr_t sym_offset;
+};
+
+/* Struct representing a library dependency for one of our given compartments
+ */
+struct LibDependency
+{
+    char* lib_name;
+    char* lib_path;
+    size_t lib_segs_count;
+    size_t lib_segs_size;
+    void* lib_mem_base;
+    struct SegmentMap** lib_segs;
+    size_t lib_syms_count;
+    struct LibDependencySymbol* lib_syms;
 };
 
 /* Struct representing ELF data necessary to load and eventually execute a
@@ -119,65 +144,67 @@ struct Compartment
     Elf64_Half elf_type;
     // Execution info
     Elf64_Half phdr;
-    Elf64_Half phentsize;
-    Elf64_Half phnum;
     void* __capability ddc;
     // ELF data
-    size_t size;
-    uintptr_t base;
+    size_t size; // size of compartment in memory
+    void* base; // address where to load compartment
     size_t entry_point_count;
-    struct entry_point** comp_fns; // TODO
-    uintptr_t* relas;
-    size_t relas_cnt;
+    struct entry_point** comp_fns;
+    void* mem_top;
     bool mapped;
     bool mapped_full;
     // Segments data
-    struct SegmentMap* segs[SEG_MAX_COUNT]; // TODO
+    struct SegmentMap** segs;
     size_t seg_count;
     size_t segs_size;
     // Scratch memory
-    uintptr_t scratch_mem_base;
+    void* scratch_mem_base;
     size_t scratch_mem_size;
     size_t scratch_mem_alloc;
 
     size_t scratch_mem_heap_size;
-    uintptr_t scratch_mem_stack_top;
+    void* scratch_mem_stack_top;
     size_t scratch_mem_stack_size;
-    uintptr_t stack_pointer;
+    void* stack_pointer;
     struct mem_alloc* alloc_head;
 
-    uintptr_t manager_caps;
+    void* manager_caps;
     size_t max_manager_caps_count;
     size_t active_manager_caps_count;
 
-    uintptr_t mng_trans_fn;
+    void* mng_trans_fn;
     size_t mng_trans_fn_sz;
+
+    // Only for shared object compartments
+    size_t rela_maps_count;
+    struct CompRelaMapping* rela_maps;
+    size_t lib_deps_count;
+    struct LibDependency** lib_deps;
+
     // Hardware info - maybe move
     size_t page_size;
+
     // Misc
     short curr_intercept_count;
-    struct intercept_patch patches[INTERCEPT_FUNC_COUNT];
+    struct intercept_patch* intercept_patches;
 };
-
-extern struct Compartment** comps;
 
 int entry_point_cmp(const void*, const void*);
 struct Compartment* comp_init();
-struct Compartment* comp_from_elf(char*, struct ConfigEntryPoint*, size_t);
-void comp_register_ddc(struct Compartment*);
-void comp_add_intercept(struct Compartment*, uintptr_t, struct func_intercept);
+struct Compartment* comp_from_elf(char*, char**, size_t, char**, void**, size_t, void*);
+void comp_add_intercept(struct Compartment*, uintptr_t, uintptr_t);
 void comp_stack_push(struct Compartment*, const void*, size_t);
 void comp_map(struct Compartment*);
 void comp_map_full(struct Compartment*);
 int64_t comp_exec(struct Compartment*, char*, void*, size_t);
 void comp_clean(struct Compartment*);
 
-void log_new_comp(struct Compartment*);
 struct Compartment* find_comp(struct Compartment*);
 
-void setup_stack(struct Compartment*);
-
-void comp_print(struct Compartment*);
-void segmap_print(struct SegmentMap*);
+static ssize_t do_pread(int, void*, size_t, off_t);
+static Elf64_Sym* find_symbols(const char**, size_t, bool, Elf64_Sym*, char*, size_t);
+static char* find_in_dir(const char*, char*);
+static void init_comp_scratch_mem(struct Compartment*);
+static void init_lib_dep_info(struct LibDependency*, struct Compartment*);
 
 #endif // _COMPARTMENT_H

--- a/include/intercept.h
+++ b/include/intercept.h
@@ -1,0 +1,82 @@
+#ifndef _INTERCEPT_H
+#define _INTERCEPT_H
+
+#include <assert.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdarg.h>
+
+// vDSO wrapper needed includes
+#include <time.h>
+
+#include "cheriintrin.h"
+
+#include "mem_mng.h"
+
+// Forward declarations
+struct Compartment;
+extern struct Compartment* loaded_comp;
+int64_t exec_comp(struct Compartment*, char*, char**);
+struct Compartment* manager_get_compartment_by_id(size_t);
+
+extern void* __capability manager_ddc;
+
+// Number of capabilities required to perform a transition
+#define COMP_RETURN_CAPS_COUNT 2
+
+// Capabilities required to transition back into the manager once compartment
+// execution has finished
+extern void* __capability comp_return_caps[COMP_RETURN_CAPS_COUNT];
+
+// Capability used to point to pair of capabilities when transitioning out of a
+// compartment via an intercept
+extern void* __capability sealed_redirect_cap;
+
+/* Data required to perform the transition for an intercepted function
+ */
+struct func_intercept {
+    char* func_name;
+    void* redirect_func;
+    void* __capability intercept_pcc;
+};
+
+/* This function expects the argument be passed in `x10`, rather than `x0`, as
+ * well as using `c29` as an argument for the DDC to transition to in order to
+ * allow the intercept to work. It is expected to be called only in very
+ * specific circumstances, and the signature is more illustrative than
+ * functional. As such, it shouldn't be called from a C context, as that will
+ * most likely break things.
+ */
+void intercept_wrapper();
+
+void setup_intercepts();
+
+time_t intercepted_time(time_t*);
+FILE* intercepted_fopen(const char*, const char*);
+size_t intercepted_fread(void* __restrict, size_t, size_t, FILE* __restrict);
+size_t intercepted_fwrite(void* __restrict, size_t, size_t, FILE* __restrict);
+int intercepted_fclose(FILE*);
+int intercepted_getc(FILE*);
+int intercepted_fputc(int, FILE*);
+int intercepted___srget(FILE*);
+
+void* my_realloc(void*, size_t);
+void* my_malloc(size_t);
+void my_free(void*);
+int my_fprintf(FILE*, const char*, ...);
+
+size_t my_call_comp(size_t, char*, void*, size_t);
+static const struct func_intercept to_intercept_funcs[] = {
+    /* vDSO funcs */
+    { "time"     , (void*) intercepted_time    },
+    /* Mem funcs */
+    { "malloc"   , (void*) my_malloc       },
+    { "realloc"  , (void*) my_realloc      },
+    { "free"     , (void*) my_free         },
+};
+//
+// Functions to be intercepted and associated data
+#define INTERCEPT_FUNC_COUNT sizeof(to_intercept_funcs) / sizeof(to_intercept_funcs[0])
+extern struct func_intercept comp_intercept_funcs[INTERCEPT_FUNC_COUNT];
+
+#endif // _INTERCEPT_H

--- a/include/manager.h
+++ b/include/manager.h
@@ -2,83 +2,28 @@
 #define _MANAGER_H
 
 #include <assert.h>
-#include <string.h>
-#include <unistd.h>
 #include <dlfcn.h>
-#include <sys/auxv.h>
-#include <stdarg.h>
+#include <err.h>
 #include <stddef.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <string.h>
-
-// vDSO wrapper needed includes
-#include <time.h>
+#include <string.h>
+#include <sys/auxv.h>
+#include <unistd.h>
 
 // Third-party libraries
 #include "toml.h"
 
+#include "intercept.h"
+#include "compartment.h"
+
+#define align_down(x, align)    __builtin_align_down(x, align)
+#define align_up(x, align)      __builtin_align_up(x, align)
+
 extern void* __capability manager_ddc;
-
-/* Data required to perform the transition for an intercepted function
- */
-struct func_intercept {
-    char* func_name;
-    uintptr_t redirect_func;
-    void* __capability intercept_ddc;
-    void* __capability intercept_pcc;
-    void* __capability redirect_cap;
-};
-
-/* This function expects the argument be passed in `x10`, rather than `x0`, as
- * well as using `c29` as an argument for the DDC to transition to in order to
- * allow the intercept to work. It is expected to be called only in very
- * specific circumstances, and the signature is more illustrative than
- * functional. As such, it shouldn't be called from a C context, as that will
- * most likely break things.
- */
-void intercept_wrapper(void* to_call_fn);
-
-void setup_intercepts();
-
-time_t manager_time(time_t*);
-FILE* manager_fopen(const char*, const char*);
-size_t manager_fread(void* __restrict, size_t, size_t, FILE* __restrict);
-size_t manager_fwrite(void* __restrict, size_t, size_t, FILE* __restrict);
-int manager_fclose(FILE*);
-int manager_getc(FILE*);
-int manager_fputc(int, FILE*);
-int manager___srget(FILE*);
-
-void* my_realloc(void*, size_t);
-void* my_malloc(size_t);
-void my_free(void*);
-int my_fprintf(FILE*, const char*, ...);
-
-size_t my_call_comp(size_t, char*, void*, size_t);
-static const struct func_intercept to_intercept_funcs[] = {
-    /* vDSO funcs */
-    { "time"     , (uintptr_t) manager_time    },
-    /* Mem funcs */
-    { "malloc"   , (uintptr_t) my_malloc       },
-    { "realloc"  , (uintptr_t) my_realloc      },
-    { "free"     , (uintptr_t) my_free         },
-    { "fprintf"  , (uintptr_t) my_fprintf      },
-    /* Compartment funcs */
-    { "call_comp", (uintptr_t) my_call_comp    },
-    /* Other funcs */
-    { "fopen"    , (uintptr_t) manager_fopen   },
-    { "fread"    , (uintptr_t) manager_fread   },
-    { "fwrite"   , (uintptr_t) manager_fwrite  },
-    { "fclose"   , (uintptr_t) manager_fclose  },
-    { "getc"     , (uintptr_t) manager_getc    },
-    { "fputc"    , (uintptr_t) manager_fputc   },
-    { "__srget"  , (uintptr_t) manager___srget },
-};
-//
-// Functions to be intercepted and associated data
-#define INTERCEPT_FUNC_COUNT sizeof(to_intercept_funcs) / sizeof(to_intercept_funcs[0])
-extern struct func_intercept comp_intercept_funcs[INTERCEPT_FUNC_COUNT];
+extern struct CompWithEntries** comps;
+extern struct Compartment* loaded_comp;
 
 /*******************************************************************************
  * Utility Functions
@@ -90,21 +35,34 @@ void print_full_cap(uintcap_t);
  * Compartment
  ******************************************************************************/
 
-// Number of capabilities required to perform a transition
-#define COMP_RETURN_CAPS_COUNT 2
-
 // Compartment configuration file suffix
 extern const char* comp_config_suffix;
 
-// Capabilities required to transition back into the manager once compartment
-// execution has finished
-extern void* __capability comp_return_caps[COMP_RETURN_CAPS_COUNT];
+/* Struct representing configuration data for one entry point; this is just
+ * information that we expect to appear in the compartment, as given by its
+ * compartment configuration file
+ */
+struct ConfigEntryPoint
+{
+    const char* name;
+    size_t arg_count;
+    char** args_type;
+};
+
+struct CompWithEntries
+{
+    struct Compartment* comp;
+    struct ConfigEntryPoint* cep;
+};
+
+void* get_next_comp_addr(void);
+struct Compartment* register_new_comp(char*, bool);
+int64_t exec_comp(struct Compartment*, char*, char**);
 
 struct Compartment* manager_find_compartment_by_addr(void*);
 struct Compartment* manager_find_compartment_by_ddc(void* __capability);
 struct Compartment* manager_get_compartment_by_id(size_t);
 
-#include "compartment.h"
 
 // TODO stack setup when we transition into the compartment; unsure if needed,
 // but keep for now, just in case
@@ -125,11 +83,9 @@ union arg_holder
 };
 
 char* prep_config_filename(char*);
-struct ConfigEntryPoint* parse_compartment_config(char*, size_t*);
+void clean_all_comps();
+void clean_comp(struct Compartment*);
 void clean_compartment_config(struct ConfigEntryPoint*, size_t);
-struct ConfigEntryPoint get_entry_point(char*, struct ConfigEntryPoint*, size_t);
-void* prepare_compartment_args(char** args, struct ConfigEntryPoint);
-struct ConfigEntryPoint* set_default_entry_point(struct ConfigEntryPoint*);
 
 /*******************************************************************************
  * Memory allocation

--- a/include/mem_mng.h
+++ b/include/mem_mng.h
@@ -10,8 +10,6 @@
 
 #include "compartment.h"
 
-struct Compartment;
-
 // TODO consider single linked list
 struct mem_alloc
 {

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -3,6 +3,7 @@ add_library(chcomp STATIC
     manager.c
     mem_mng.c
     compartment.c
+    intercept.c
     transition.S
     )
 target_include_directories(chcomp PRIVATE ${INCLUDE_DIR} ${TOML_INCLUDE_DIR})

--- a/src/compartment.c
+++ b/src/compartment.c
@@ -1,8 +1,5 @@
 #include "compartment.h"
 
-static size_t comps_id = 0;
-struct Compartment** comps;
-
 /* Initialize some values of the Compartment struct. The rest are expected to
  * be set in `comp_from_elf`.
  */
@@ -10,8 +7,8 @@ struct Compartment*
 comp_init()
 {
     // TODO order
-    struct Compartment* new_comp = (struct Compartment*) malloc(sizeof(struct Compartment));
-    new_comp->id = comps_id++;
+    struct Compartment* new_comp =
+        (struct Compartment*) malloc(sizeof(struct Compartment));
 
     new_comp->phdr = 0;
     new_comp->ddc = NULL;
@@ -25,10 +22,11 @@ comp_init()
     new_comp->seg_count = 0;
     new_comp->segs_size = 0;
     new_comp->mng_trans_fn_sz = sizeof(uint32_t) * COMP_TRANS_FN_INSTR_CNT; // TODO ptr arithmetic
-    new_comp->relas_cnt = 0;
-    new_comp->page_size = sysconf(_SC_PAGESIZE);
     new_comp->phdr = 0;
     new_comp->alloc_head = NULL;
+
+    new_comp->rela_maps_count = 0;
+
     new_comp->page_size = sysconf(_SC_PAGESIZE);
     new_comp->curr_intercept_count = 0;
 
@@ -53,17 +51,18 @@ entry_point_cmp(const void* val1, const void* val2)
  * a `struct Compartment`. At this point, we only read data.
  */
 struct Compartment*
-comp_from_elf(char* filename, struct ConfigEntryPoint* entry_points, size_t entry_point_count)
+comp_from_elf(char* filename,
+              char** entry_points, size_t entry_point_count,
+              char** intercepts, void** intercept_addrs, size_t intercept_count,
+              void* new_comp_base)
 {
     struct Compartment* new_comp = comp_init();
-    int pread_res;
 
     new_comp->fd = open(filename, O_RDONLY);
     if (new_comp->fd == -1)
     {
-        printf("Error opening compartment file  %s!\n", filename);
         free(new_comp);
-        exit(1);
+        errx(1, "Error opening compartment file  %s!\n", filename);
     }
 
     assert(entry_points);
@@ -73,73 +72,72 @@ comp_from_elf(char* filename, struct ConfigEntryPoint* entry_points, size_t entr
     // Read elf headers
     Elf64_Ehdr comp_ehdr;
     assert(new_comp->fd != -1);
-    pread_res = pread(new_comp->fd, &comp_ehdr, sizeof(comp_ehdr), 0);
-    assert(pread_res != -1);
+    do_pread(new_comp->fd, &comp_ehdr, sizeof(Elf64_Ehdr), 0);
     new_comp->elf_type = comp_ehdr.e_type;
     assert(new_comp->elf_type == ET_DYN || new_comp->elf_type == ET_EXEC);
 
     struct stat elf_fd_stat;
     fstat(new_comp->fd, &elf_fd_stat);
+    // TODO re-check these
     new_comp->size = elf_fd_stat.st_size;
-    new_comp->phentsize = comp_ehdr.e_phentsize;
-    new_comp->phnum = comp_ehdr.e_phnum;
 
     // Read program headers
     Elf64_Phdr comp_phdr;
-    size_t align_size_correction;
+    ptrdiff_t align_size_correction;
     bool first_load_header = true;
     for (size_t i = 0; i < comp_ehdr.e_phnum; ++i)
     {
-        pread_res = pread((int) new_comp->fd, &comp_phdr, sizeof(comp_phdr),
-                comp_ehdr.e_phoff + i * sizeof(comp_phdr));
-        assert(pread_res != -1);
+        do_pread((int) new_comp->fd, &comp_phdr, sizeof(comp_phdr),
+                 comp_ehdr.e_phoff + i * sizeof(comp_phdr));
 
-        /*if (comp_phdr.p_offset <= comp_ehdr.e_phoff &&*/
-                /*(comp_ehdr.e_phoff + comp_ehdr.e_phnum * comp_ehdr.e_phentsize)*/
-                    /*<= comp_phdr.p_offset + comp_phdr.p_filesz)*/
-        /*{*/
-            /*new_comp->phdr = 0; // TODO?*/
-            /*continue;*/
-        /*}*/
-
+        // We only need to keep `PT_LOAD` segments, so we can map them later
         if (comp_phdr.p_type != PT_LOAD)
         {
             continue;
         }
 
-        // Compute loading address of compartment
+        if (new_comp->elf_type == ET_DYN)
+        {
+            new_comp->base = new_comp_base;
+        }
+        // Compute loading address of compartment for static binary
         // TODO empirically, the first `LOAD` program header seems to expect to be
         // loaded at the lowest address; is this correct?
-        if (first_load_header)
+        else if (first_load_header)
         {
-            const unsigned long new_comp_base = comp_phdr.p_vaddr;
-            assert(new_comp_base % new_comp->page_size == 0);
+            void* new_comp_base = (void*) comp_phdr.p_vaddr;
+            assert((uintptr_t) new_comp_base % new_comp->page_size == 0);
             new_comp->base = new_comp_base;
             first_load_header = false;
         }
 
+        // Setup mapping info for the current segment
         struct SegmentMap* this_seg =
             (struct SegmentMap*) malloc(sizeof(struct SegmentMap));
         assert(this_seg != NULL);
         if (new_comp->elf_type == ET_DYN /*|| new_comp->elf_type == ET_EXEC*/) // TODO distinguish PIE exec vs non-PIE exec
         {
-            unsigned long curr_seg_base = new_comp->base + comp_phdr.p_vaddr;
+            void* curr_seg_base = (char*) new_comp->base + comp_phdr.p_vaddr;
             this_seg->mem_bot = align_down(curr_seg_base, new_comp->page_size);
-            align_size_correction = curr_seg_base - this_seg->mem_bot;
-            this_seg->mem_top = curr_seg_base + comp_phdr.p_memsz;
+            align_size_correction = (char*) curr_seg_base - (char*) this_seg->mem_bot;
+            this_seg->mem_top = (char*) curr_seg_base + comp_phdr.p_memsz;
         }
         else if (new_comp->elf_type == ET_EXEC)
         {
-            this_seg->mem_bot = align_down(comp_phdr.p_vaddr, new_comp->page_size);
-            align_size_correction = comp_phdr.p_vaddr - this_seg->mem_bot;
-            this_seg->mem_top = comp_phdr.p_vaddr + comp_phdr.p_memsz;
+            // TODO maybe just remove this if if we don't want to support
+            // static binaries anymore
+            assert(false);
+            this_seg->mem_bot =
+                align_down((void*) comp_phdr.p_vaddr, new_comp->page_size);
+            align_size_correction =
+                (char*) comp_phdr.p_vaddr - (char*) this_seg->mem_bot;
+            this_seg->mem_top = (char*) comp_phdr.p_vaddr + comp_phdr.p_memsz;
         }
         else
         {
-            assert(false && "Unhandled elf type"); // TODO move elsewhere
+            errx(1, "Unhandled ELF type");
         }
         this_seg->offset = align_down(comp_phdr.p_offset, new_comp->page_size);
-        /*this_seg->size = comp_phdr.p_filesz + (comp_phdr.p_offset & (new_comp->page_size - 1)); // TODO ????*/
         this_seg->mem_sz = comp_phdr.p_memsz + align_size_correction;
         this_seg->file_sz = comp_phdr.p_filesz + align_size_correction;
         this_seg->correction = align_size_correction;
@@ -147,184 +145,282 @@ comp_from_elf(char* filename, struct ConfigEntryPoint* entry_points, size_t entr
                                 (comp_phdr.p_flags & PF_W ? PROT_WRITE : 0) |
                                 (comp_phdr.p_flags & PF_X ? PROT_EXEC : 0);
 
+        new_comp->segs =
+            realloc(new_comp->segs,
+                    (new_comp->seg_count + 1) * sizeof(struct SegmentMap*));
         new_comp->segs[new_comp->seg_count] = this_seg;
         new_comp->seg_count += 1;
-        new_comp->segs_size += this_seg->mem_sz;
+        new_comp->segs_size += align_up(this_seg->mem_sz, comp_phdr.p_align);
     }
 
-    // Define scratch memory available
-    new_comp->scratch_mem_base = align_up(new_comp->segs[new_comp->seg_count - 1]->mem_top + new_comp->page_size, new_comp->page_size);
-    new_comp->max_manager_caps_count = 10; // TODO
-    new_comp->scratch_mem_heap_size = 0x800000UL;
-    new_comp->scratch_mem_size =
-            new_comp->scratch_mem_heap_size +
-            new_comp->max_manager_caps_count * sizeof(void* __capability) +
-            new_comp->mng_trans_fn_sz;;
-    new_comp->scratch_mem_alloc = 0;
-    new_comp->scratch_mem_stack_top = align_down(new_comp->scratch_mem_base + new_comp->scratch_mem_heap_size, 16);
-    new_comp->scratch_mem_stack_size = 0x80000UL;
-    new_comp->manager_caps = new_comp->scratch_mem_stack_top;
-    new_comp->active_manager_caps_count = 0;
-    new_comp->mng_trans_fn = new_comp->manager_caps + new_comp->max_manager_caps_count * sizeof(void* __capability);
-    assert(new_comp->scratch_mem_base % 16 == 0);
-    assert((new_comp->scratch_mem_base + new_comp->scratch_mem_size) % 16 == 0);
-    assert(new_comp->scratch_mem_stack_top % 16 == 0);
-    assert((new_comp->scratch_mem_stack_top - new_comp->scratch_mem_stack_size) % 16 == 0);
-    assert(new_comp->scratch_mem_size % 16 == 0);
+    // Load `.shstr` section, so we can check section names
+    Elf64_Shdr comp_sh_strtb_hdr;
+    do_pread((int) new_comp->fd, &comp_sh_strtb_hdr, sizeof(Elf64_Shdr),
+             comp_ehdr.e_shoff + comp_ehdr.e_shstrndx * sizeof(Elf64_Shdr));
+    char* comp_sh_strtb = malloc(comp_sh_strtb_hdr.sh_size);
+    do_pread((int) new_comp->fd, comp_sh_strtb, comp_sh_strtb_hdr.sh_size,
+             comp_sh_strtb_hdr.sh_offset);
+
+    init_comp_scratch_mem(new_comp);
+    new_comp->mem_top = new_comp->scratch_mem_stack_top;
+
+    // Find indices of interest that we'll use later
+    const size_t headers_of_interest_count = 3;
+    size_t found_headers = 0;
+    Elf64_Shdr comp_symtb_shdr;
+    Elf64_Shdr comp_rela_plt_shdr;
+    Elf64_Shdr comp_dynamic_shdr;
+    Elf64_Shdr curr_shdr;
+    for (size_t i = 0; i < comp_ehdr.e_shnum; ++i)
+    {
+        do_pread((int) new_comp->fd, &curr_shdr, sizeof(Elf64_Shdr),
+                 comp_ehdr.e_shoff + i * sizeof(Elf64_Shdr));
+
+        if (curr_shdr.sh_type == SHT_SYMTAB)
+        {
+            comp_symtb_shdr = curr_shdr;
+            found_headers += 1;
+        }
+        // Lookup `.rela.plt` to eagerly load relocatable function addresses
+        else if (curr_shdr.sh_type == SHT_RELA &&
+                 !strcmp(&comp_sh_strtb[curr_shdr.sh_name], ".rela.plt"))
+        {
+            comp_rela_plt_shdr = curr_shdr;
+            found_headers += 1;
+        }
+        // Lookup `.dynamic` to find library dependencies
+        else if (curr_shdr.sh_type == SHT_DYNAMIC)
+        {
+            comp_dynamic_shdr = curr_shdr;
+            found_headers += 1;
+        }
+
+        if (headers_of_interest_count == found_headers)
+        {
+            break;
+        }
+    }
+    assert(headers_of_interest_count == found_headers);
+
+    if (new_comp->elf_type == ET_DYN)
+    {
+        // Traverse `.rela.plt`, so we can see which function addresses we need
+        // to eagerly load
+        Elf64_Rela* comp_rela_plt = malloc(comp_rela_plt_shdr.sh_size);
+        do_pread((int) new_comp->fd, comp_rela_plt, comp_rela_plt_shdr.sh_size,
+                 comp_rela_plt_shdr.sh_offset);
+        size_t rela_count = comp_rela_plt_shdr.sh_size / sizeof(Elf64_Rela);
+
+        Elf64_Shdr dyn_sym_hdr;
+        do_pread((int) new_comp->fd, &dyn_sym_hdr,
+                 sizeof(Elf64_Shdr),
+                 comp_ehdr.e_shoff + comp_rela_plt_shdr.sh_link * sizeof(Elf64_Shdr));
+        Elf64_Sym* dyn_sym_tbl = malloc(dyn_sym_hdr.sh_size);
+        do_pread((int) new_comp->fd, dyn_sym_tbl, dyn_sym_hdr.sh_size,
+                 dyn_sym_hdr.sh_offset);
+
+        Elf64_Shdr dyn_str_hdr;
+        do_pread((int) new_comp->fd, &dyn_str_hdr,
+                 sizeof(Elf64_Shdr),
+                 comp_ehdr.e_shoff + dyn_sym_hdr.sh_link * sizeof(Elf64_Shdr));
+        char* dyn_str_tbl = malloc(dyn_str_hdr.sh_size);
+        do_pread((int) new_comp->fd, dyn_str_tbl, dyn_str_hdr.sh_size,
+                 dyn_str_hdr.sh_offset);
+
+        new_comp->rela_maps = calloc(rela_count, sizeof(struct CompRelaMapping));
+        new_comp->rela_maps_count = rela_count;
+
+        // Log symbols that will need to be relocated eagerly at maptime
+        Elf64_Rela curr_rela;
+        for (size_t j = 0; j < new_comp->rela_maps_count; ++j)
+        {
+            curr_rela = comp_rela_plt[j];
+            size_t curr_rela_sym_idx = ELF64_R_SYM(curr_rela.r_info);
+            Elf64_Sym curr_rela_sym = dyn_sym_tbl[curr_rela_sym_idx];
+            char* curr_rela_name = malloc(strlen(&dyn_str_tbl[curr_rela_sym.st_name]) + 1);
+            strcpy(curr_rela_name, &dyn_str_tbl[curr_rela_sym.st_name]);
+            if (ELF64_ST_BIND(curr_rela_sym.st_info) == STB_WEAK)
+            {
+                // Do not handle weak-bind symbols
+                // TODO should we?
+                struct CompRelaMapping crm = { curr_rela_name, 0, 0 };
+                new_comp->rela_maps[j] = crm;
+                continue;
+            } // TODO collapse
+
+            struct CompRelaMapping crm = {
+                curr_rela_name,
+                curr_rela.r_offset + (char*) new_comp->base,
+                NULL };
+            new_comp->rela_maps[j] = crm;
+        }
+        free(comp_rela_plt);
+        free(dyn_sym_tbl);
+
+        // Find additional library dependencies
+        Elf64_Dyn* comp_dyn_entries = malloc(comp_dynamic_shdr.sh_size);
+        do_pread((int) new_comp->fd, comp_dyn_entries,
+                 comp_dynamic_shdr.sh_size, comp_dynamic_shdr.sh_offset);
+
+        for (size_t i = 0;
+             i < comp_dynamic_shdr.sh_size / sizeof(Elf64_Dyn);
+             ++i)
+        {
+            if (comp_dyn_entries[i].d_tag == DT_NEEDED)
+            {
+                struct LibDependency* new_lib_dep =
+                    malloc(sizeof(struct LibDependency));
+                new_lib_dep->lib_name =
+                    malloc(strlen(&dyn_str_tbl[comp_dyn_entries[i].d_un.d_val]) + 1);
+                strcpy(
+                    new_lib_dep->lib_name,
+                    &dyn_str_tbl[comp_dyn_entries[i].d_un.d_val]);
+                new_comp->lib_deps_count += 1;
+                new_comp->lib_deps =
+                    realloc(new_comp->lib_deps,
+                            new_comp->lib_deps_count *
+                                sizeof(struct LibDependency));
+                new_comp->lib_deps[new_comp->lib_deps_count - 1] = new_lib_dep;
+            }
+        }
+
+        free(dyn_str_tbl);
+        free(comp_dyn_entries);
+    }
+
+    // Find library files in `COMP_LIBRARY_PATH` to fulfill dependencies
+    for (size_t i = 0; i < new_comp->lib_deps_count; ++i)
+    {
+        struct LibDependency* curr_dep = new_comp->lib_deps[i];
+        // TODO move env var name to constant
+        assert(getenv("COMP_LIBRARY_PATH"));
+        char* lib_path =
+            find_in_dir(curr_dep->lib_name, getenv("COMP_LIBRARY_PATH"));
+        if (!lib_path)
+        {
+            errx(1, "Could not find file for dependency %s!\n", curr_dep->lib_name);
+        }
+        curr_dep->lib_path = malloc(strlen(lib_path));
+        strcpy(curr_dep->lib_path, lib_path);
+        init_lib_dep_info(curr_dep, new_comp);
+        new_comp->mem_top =
+            (char*) curr_dep->lib_mem_base +
+            (uintptr_t) curr_dep->lib_segs[curr_dep->lib_segs_count - 1]->mem_top;
+    }
 
     // Find functions of interest, particularly entry points, and functions to
     // intercept
-    Elf64_Shdr comp_symtb_hdr; // TODO change name
-    for (size_t i = 0; i < comp_ehdr.e_shnum; ++i)
+    Elf64_Shdr comp_strtb_hdr;
+    do_pread((int) new_comp->fd, &comp_strtb_hdr, sizeof(Elf64_Shdr),
+        comp_ehdr.e_shoff + comp_symtb_shdr.sh_link * sizeof(Elf64_Shdr));
+
+    // XXX The string table is read in `comp_strtb` as a sequence of
+    // variable-length strings. Then, symbol names are obtained by indexing at
+    // the offset where the name for that symbol begins. Therefore, the type
+    // `char*` for the string table makes sense.
+    char* comp_strtb = malloc(comp_strtb_hdr.sh_size);
+    do_pread((int) new_comp->fd, comp_strtb, comp_strtb_hdr.sh_size, comp_strtb_hdr.sh_offset);
+
+    Elf64_Sym* comp_symtb = malloc(comp_symtb_shdr.sh_size);
+    do_pread((int) new_comp->fd, comp_symtb, comp_symtb_shdr.sh_size, comp_symtb_shdr.sh_offset);
+
+    // Find symbols for entry_points
+    Elf64_Sym* ep_syms =
+        find_symbols((const char**) entry_points, entry_point_count,
+                     true, comp_symtb, comp_strtb, comp_symtb_shdr.sh_size);
+    for (size_t i = 0; i < entry_point_count; ++i)
     {
-        pread_res = pread((int) new_comp->fd, &comp_symtb_hdr, sizeof(Elf64_Shdr),
-                comp_ehdr.e_shoff + i * sizeof(Elf64_Shdr));
-        assert(pread_res != -1);
-
-        // Find functions of interest in injected ELF file
-        if (comp_symtb_hdr.sh_type == SHT_SYMTAB)
+        struct entry_point* new_entry_point = malloc(sizeof(struct entry_point));
+        new_entry_point->fn_name = entry_points[i];
+        switch(new_comp->elf_type)
         {
-            Elf64_Shdr comp_strtb_hdr;
-            pread_res = pread((int) new_comp->fd, &comp_strtb_hdr, sizeof(Elf64_Shdr), comp_ehdr.e_shoff + comp_symtb_hdr.sh_link * sizeof(Elf64_Shdr));
-            assert(pread_res != -1);
-            char* comp_strtb = (char*) malloc(comp_strtb_hdr.sh_size);
-            pread_res = pread((int) new_comp->fd, comp_strtb, comp_strtb_hdr.sh_size, comp_strtb_hdr.sh_offset);
-            assert(pread_res != -1);
-
-            Elf64_Sym* comp_symtb = (Elf64_Sym*) malloc(comp_symtb_hdr.sh_size);
-            pread_res = pread((int) new_comp->fd, comp_symtb, comp_symtb_hdr.sh_size, comp_symtb_hdr.sh_offset);
-            assert(pread_res != -1);
-
-            size_t syms_count = comp_symtb_hdr.sh_size / sizeof(Elf64_Sym);
-            Elf64_Sym curr_sym;
-            size_t syms_to_find_count = entry_point_count;
-            const char** syms_found = malloc(syms_to_find_count);
-            size_t syms_found_count = 0;
-            for (size_t j = 0; j < syms_count; ++j)
+            case ET_DYN:
             {
-                curr_sym = comp_symtb[j];
-                for (size_t k = 0; k < syms_to_find_count; ++k)
-                {
-                    if (!strcmp(entry_points[k].name, &comp_strtb[curr_sym.st_name]))
-                    {
-                        struct entry_point* new_entry_point = malloc(sizeof(struct entry_point));
-                        new_entry_point->fn_name = entry_points[k].name;
-                        new_entry_point->arg_count = entry_points[k].arg_count;
-                        new_entry_point->arg_types = entry_points[k].args_type;
-                        switch(new_comp->elf_type)
-                        {
-                            case ET_DYN:
-                            {
-                                new_entry_point->fn_addr
-                                    = new_comp->base + curr_sym.st_value;
-                                break;
-                            }
-                            case ET_EXEC:
-                            {
-                                new_entry_point->fn_addr
-                                    = curr_sym.st_value;
-                                break;
-                            }
-                            default:
-                                assert(false);
-                        }
-                        new_comp->comp_fns[new_comp->entry_point_count] =
-                            new_entry_point;
-                        new_comp->entry_point_count += 1;
-                        syms_found[syms_found_count] = entry_points[k].name;
-                        syms_found_count += 1;
-                    }
-                    else
-                    {
-                        for (size_t i = 0; i < sizeof(to_intercept_funcs) / sizeof(to_intercept_funcs[0]); ++i)
-                        {
-                            if (!strcmp(comp_intercept_funcs[i].func_name, &comp_strtb[curr_sym.st_name]))
-                            {
-                                comp_add_intercept(new_comp, curr_sym.st_value, comp_intercept_funcs[i]);
-                                break;
-                            }
-                        }
-                    }
-                }
+                new_entry_point->fn_addr = (char*) new_comp->base + ep_syms[i].st_value;
+                break;
             }
-        free(comp_symtb);
-        free(comp_strtb);
-        if (syms_found_count != syms_to_find_count)
-        {
-            const char** syms_not_found = malloc(syms_to_find_count);
-            size_t not_found_idx = 0;
-            for (size_t i = 0; i < syms_to_find_count; ++i)
+            case ET_EXEC:
             {
-                bool not_found = true;
-                for (size_t j = 0; j < syms_found_count; ++j)
-                {
-                    if (!strcmp(syms_found[j], entry_points[i].name))
-                    {
-                        not_found = false;
-                        break;
-                    }
-                }
-                if (not_found)
-                {
-                    syms_not_found[not_found_idx] = entry_points[i].name;
-                    not_found_idx += 1;
-                }
+                new_entry_point->fn_addr = (void*) ep_syms[i].st_value;
+                break;
             }
-            printf("Did not find following entry points [ ");
-            for (size_t i = 0; i < not_found_idx; ++i)
-            {
-                printf("%s ", syms_not_found[i]);
-            }
-            printf("]\n");
-            free(syms_not_found);
-            free(syms_found);
-            assert(false);
+            default:
+                errx(1, "Invalid ELF type");
         }
-        free(syms_found);
-        }
-        // TODO still need relas check or consider only static executables?
-        else if (comp_symtb_hdr.sh_type == SHT_RELA) // TODO change name && consider SH_REL
+        new_comp->comp_fns[new_comp->entry_point_count] = new_entry_point;
+        new_comp->entry_point_count += 1;
+    }
+    free(ep_syms);
+
+    // Find symbols for intercepts
+    char** intercept_names = calloc(intercept_count, sizeof(char*));
+    const char* so_plt_suffix = "@plt";
+    for (size_t i = 0; i < intercept_count; ++i)
+    {
+        if (new_comp->elf_type == ET_DYN)
         {
-            assert(false && "currently we only handle static executables");
-            if (comp_symtb_hdr.sh_info == 0) // TODO better identify the plt relocation section
-            {
-                continue;
-            }
-
-            new_comp->relas_cnt = comp_symtb_hdr.sh_size / sizeof(Elf64_Rela);
-            new_comp->relas = (uintptr_t*) malloc(new_comp->relas_cnt * sizeof(uintptr_t));
-            Elf64_Rela* comp_relas = (Elf64_Rela*) malloc(comp_symtb_hdr.sh_size);
-            pread_res = pread((int) new_comp->fd, comp_relas, comp_symtb_hdr.sh_size, comp_symtb_hdr.sh_offset);
-            assert(pread_res != -1);
-
-            for (size_t j = 0; j < new_comp->relas_cnt; ++j)
-            {
-                new_comp->relas[j] = comp_relas[j].r_offset;
-                // TODO double check
-                /*comp_relas[j].r_offset += new_comp->base;*/
-                /*uintptr_t old_plt_val = (uintptr_t) *((void**) comp_relas[j].r_offset);*/
-                /*old_plt_val += new_comp->base;*/
-            }
-
-            free(comp_relas);
+            size_t to_intercept_name_len = strlen(intercepts[i]) + strlen(so_plt_suffix) + 1;
+            intercept_names[i] = malloc(to_intercept_name_len);
+            strcpy(intercept_names[i], intercepts[i]);
+            strcat(intercept_names[i], so_plt_suffix);
+        }
+        else if (new_comp->elf_type == ET_EXEC)
+        {
+            intercept_names[i] = malloc(strlen(intercepts[i]) + 1);
+            strcpy(intercept_names[i], intercepts[i]);
         }
         else
         {
-            continue;
+            errx(1, "Invalid ELF type");
         }
     }
+    Elf64_Sym* intercept_syms =
+        find_symbols((const char**) intercept_names, intercept_count, false,
+                     comp_symtb, comp_strtb, comp_symtb_shdr.sh_size);
+    for (size_t i = 0; i < intercept_count; ++i)
+    {
+        // TODO better way to check if we didn't find an intercept?
+        if (intercept_syms[i].st_value != 0)
+        {
+            comp_add_intercept(new_comp, intercept_syms[i].st_value, (uintptr_t) intercept_addrs[i]);
+        }
+        free(intercept_names[i]);
+    }
+    free(intercept_names);
+    free(intercept_syms);
 
-    comp_register_ddc(new_comp);
+    // Find all symbols for eager relocation mapping
+    for (size_t i = 0; i < new_comp->rela_maps_count; ++i)
+    {
+        // Ignore relocations we don't want to load, as earlier set on lookup
+        // (e.g., weak-bound symbols)
+        if (new_comp->rela_maps[i].rela_address == 0)
+        {
+            continue;
+        }
+        for (size_t j = 0; j < new_comp->lib_deps_count; ++j)
+        {
+            for (size_t k = 0; k < new_comp->lib_deps[j]->lib_syms_count; ++k)
+            {
+                if (!strcmp(new_comp->rela_maps[i].rela_name,
+                            new_comp->lib_deps[j]->lib_syms[k].sym_name))
+                {
+                    new_comp->rela_maps[i].target_func_address =
+                        (char*) new_comp->lib_deps[j]->lib_mem_base +
+                        new_comp->lib_deps[j]->lib_syms[k].sym_offset;
+                    goto found;
+                }
+            }
+        }
+        errx(1, "Did not find symbol %s!\n", new_comp->rela_maps[i].rela_name);
+        found:
+            (void) 0;
+    }
+
+    free(comp_symtb);
+    free(comp_strtb);
+
     return new_comp;
-}
-
-void
-comp_register_ddc(struct Compartment* new_comp)
-{
-    void* __capability new_ddc = cheri_address_set(manager_ddc, new_comp->base);
-    new_ddc = cheri_bounds_set(new_ddc, new_comp->size + new_comp->scratch_mem_size);
-    // TODO bounds double-check
-    new_comp->ddc = new_ddc;
 }
 
 /* For a given Compartment `new_comp`, an address `intercept_target` pointing
@@ -335,16 +431,20 @@ comp_register_ddc(struct Compartment* new_comp)
  * to call the appropriate function with higher privileges.
  */
 void
-comp_add_intercept(struct Compartment* new_comp, uintptr_t intercept_target, struct func_intercept intercept_data)
+comp_add_intercept(struct Compartment* new_comp, uintptr_t intercept_target, uintptr_t redirect_addr)
 {
     // TODO check whether negative values break anything in all these generated functions
     int32_t new_instrs[INTERCEPT_INSTR_COUNT];
     size_t new_instr_idx = 0;
-    uintptr_t comp_manager_cap_addr = new_comp->manager_caps + new_comp->active_manager_caps_count * sizeof(void* __capability); // TODO
+    const ptraddr_t comp_manager_cap_addr =
+        (ptraddr_t) new_comp->manager_caps +
+        new_comp->active_manager_caps_count * sizeof(void* __capability); // TODO
 
     const int32_t arm_function_target_register = 0b01010; // use `x10` for now
     const int32_t arm_transition_target_register = 0b01011; // use `x11` for now
 
+    // `x10` is used to hold the address of the manager function we want to
+    // execute after a jump out of the compartment
     // TODO ideally we want 1 `movz` and 3 `movk`, to be able to access any
     // address, but this is sufficient for now
     // movz x0, $target_fn_addr:lo16
@@ -352,8 +452,8 @@ comp_add_intercept(struct Compartment* new_comp, uintptr_t intercept_target, str
     assert(intercept_target < ((ptraddr_t) 1 << 32));
     const uint32_t arm_movz_instr_mask = 0b11010010100 << 21;
     const uint32_t arm_movk_instr_mask = 0b11110010101 << 21;
-    const ptraddr_t target_address_lo16 = (intercept_data.redirect_func & ((1 << 16) - 1)) << 5;
-    const ptraddr_t target_address_hi16 = (intercept_data.redirect_func >> 16) << 5;
+    const ptraddr_t target_address_lo16 = (redirect_addr & ((1 << 16) - 1)) << 5;
+    const ptraddr_t target_address_hi16 = (redirect_addr >> 16) << 5;
     const int32_t arm_movz_intr = arm_movz_instr_mask | target_address_lo16 | arm_function_target_register;
     const int32_t arm_movk_intr = arm_movk_instr_mask | target_address_hi16 | arm_function_target_register;
     new_instrs[new_instr_idx++] = arm_movz_intr;
@@ -389,7 +489,7 @@ comp_add_intercept(struct Compartment* new_comp, uintptr_t intercept_target, str
     new_instrs[new_instr_idx++] = arm_ldr_instr;
 
     // `b` instr generation
-    ptraddr_t arm_b_instr_offset = (new_comp->mng_trans_fn - (intercept_target + new_instr_idx * sizeof(uint32_t))) / 4;
+    ptraddr_t arm_b_instr_offset = (((uintptr_t) new_comp->mng_trans_fn) - (intercept_target + new_instr_idx * sizeof(uint32_t))) / 4;
     assert(arm_b_instr_offset < (1 << 27));
     arm_b_instr_offset &= (1 << 26) - 1;
     const uint32_t arm_b_instr_mask = 0b101 << 26;
@@ -402,26 +502,19 @@ comp_add_intercept(struct Compartment* new_comp, uintptr_t intercept_target, str
     memcpy(new_patch.instr, new_instrs, sizeof(new_instrs));
     __clear_cache(new_patch.instr, new_patch.instr + sizeof(new_instrs));
     new_patch.comp_manager_cap_addr = comp_manager_cap_addr;
-    new_patch.manager_cap = intercept_data.redirect_cap;
-    new_comp->patches[new_comp->curr_intercept_count] = new_patch;
+    new_patch.manager_cap = sealed_redirect_cap;
     new_comp->curr_intercept_count += 1;
+    new_comp->intercept_patches = realloc(new_comp->intercept_patches, new_comp->curr_intercept_count * sizeof(struct intercept_patch));
+    new_comp->intercept_patches[new_comp->curr_intercept_count - 1] = new_patch;
 }
 
 void
 comp_stack_push(struct Compartment* comp, const void* to_push, size_t to_push_sz)
 {
-    comp->stack_pointer -= to_push_sz;
+    comp->stack_pointer = (char*) comp->stack_pointer - to_push_sz;
     memcpy((void*) comp->stack_pointer, to_push, to_push_sz);
-    assert(comp->stack_pointer > comp->scratch_mem_stack_top - comp->scratch_mem_stack_size);
+    assert(comp->stack_pointer > (void*) ((char*) comp->scratch_mem_stack_top - comp->scratch_mem_stack_size));
 }
-
-// TODO code needed if we reimplement auxp/envp for the loader
-/*void*/
-/*comp_stack_auxval_push(struct Compartment* comp, uint64_t at_type, uint64_t at_val)*/
-/*{*/
-    /*Elf64_Auxinfo new_auxv = {at_type, {at_val} };*/
-    /*comp_stack_push(comp, &new_auxv, sizeof(new_auxv));*/
-/*}*/
 
 /* Map a struct Compartment into memory, making it ready for execution
  */
@@ -436,28 +529,45 @@ comp_map(struct Compartment* to_map)
     for (size_t i = 0; i < to_map->seg_count; ++i)
     {
         curr_seg = to_map->segs[i];
-        if (curr_seg->file_sz == curr_seg->mem_sz)
+        map_result = mmap((void*) curr_seg->mem_bot,
+                                curr_seg->mem_sz,
+                                /*curr_seg->prot_flags,*/ // TODO currently need read/write to inject the intercepts, consider better option
+                                PROT_READ | PROT_WRITE | PROT_EXEC,
+                                MAP_PRIVATE | MAP_FIXED | MAP_ANONYMOUS,
+                                -1, 0);
+        if (map_result == MAP_FAILED)
         {
-            map_result = mmap((void*) curr_seg->mem_bot,
-                                    curr_seg->file_sz,
-                                    /*curr_seg->prot_flags,*/ // TODO currently need read/write to inject the intercepts, consider better option
-                                    PROT_READ | PROT_WRITE | PROT_EXEC,
-                                    MAP_PRIVATE | MAP_FIXED,
-                                    to_map->fd, curr_seg->offset);
+            errx(1, "Error mapping comp segment idx %zu", i);
         }
-        else
+        do_pread(to_map->fd, (void*) curr_seg->mem_bot, curr_seg->file_sz,
+                 curr_seg->offset);
+    }
+
+    // Map compartment library dependencies segments
+    struct LibDependency* lib_dep;
+    struct SegmentMap* lib_dep_seg;
+    int lib_dep_fd;
+    for (size_t i = 0; i < to_map->lib_deps_count; ++i)
+    {
+        lib_dep = to_map->lib_deps[i];
+        lib_dep_fd = open(lib_dep->lib_path, O_RDONLY);
+        for (size_t j = 0; j < lib_dep->lib_segs_count; ++j)
         {
-            assert(curr_seg->mem_sz > curr_seg->file_sz);
-            map_result = mmap((void*) curr_seg->mem_bot,
-                                    curr_seg->mem_sz,
-                                    curr_seg->prot_flags,
-                                    MAP_PRIVATE | MAP_FIXED | MAP_ANONYMOUS,
-                                    -1, 0);
-            assert(map_result !=  MAP_FAILED);
-            int pread_res = pread(to_map->fd, (void*) curr_seg->mem_bot,
-                                  curr_seg->file_sz, curr_seg->offset);
-            assert(pread_res != -1);
+            lib_dep_seg = lib_dep->lib_segs[j];
+            map_result = mmap((char*) lib_dep->lib_mem_base + (uintptr_t) lib_dep_seg->mem_bot,
+                              lib_dep_seg->mem_sz,
+                              PROT_READ | PROT_WRITE | PROT_EXEC, // TODO fix
+                              MAP_PRIVATE | MAP_FIXED | MAP_ANONYMOUS,
+                              -1, 0);
+            if (map_result == MAP_FAILED)
+            {
+                errx(1, "Error mapping library %s dependency segment idx %zu",
+                        lib_dep->lib_name, j);
+            }
+            do_pread(lib_dep_fd, (char*) lib_dep->lib_mem_base + (uintptr_t) lib_dep_seg->mem_bot,
+                     lib_dep_seg->file_sz, lib_dep_seg->offset);
         }
+        close(lib_dep_fd);
     }
 
     // Map compartment scratch memory
@@ -469,7 +579,7 @@ comp_map(struct Compartment* to_map)
     assert(map_result != MAP_FAILED);
 
     // Map compartment stack
-    map_result = mmap((void*) to_map->scratch_mem_stack_top - to_map->scratch_mem_stack_size,
+    map_result = mmap((char*) to_map->scratch_mem_stack_top - to_map->scratch_mem_stack_size,
                       to_map->scratch_mem_stack_size,
                       PROT_READ | PROT_WRITE | PROT_EXEC, // TODO fix this
                       MAP_PRIVATE | MAP_FIXED | MAP_ANONYMOUS | MAP_STACK,
@@ -477,18 +587,11 @@ comp_map(struct Compartment* to_map)
     to_map->stack_pointer = to_map->scratch_mem_stack_top;
     assert(map_result != MAP_FAILED);
 
-    for (size_t i = 0; i < to_map->relas_cnt; ++i)
-    {
-        uintptr_t rela_addr = to_map->relas[i] + to_map->base;
-        uintptr_t old_plt_val = (uintptr_t) *((void**) rela_addr);
-        old_plt_val += to_map->base;
-        *((uintptr_t *) rela_addr) = old_plt_val;
-    }
-
     // Inject intercept instructions within identified intercepted functions
     for (size_t i = 0; i < to_map->curr_intercept_count; ++i)
     {
-        struct intercept_patch to_patch = to_map->patches[i];
+        struct intercept_patch to_patch = to_map->intercept_patches[i];
+        // TODO change to memcpy?
         for (size_t j = 0; j < INTERCEPT_INSTR_COUNT; ++j)
         {
             int32_t* curr_addr = to_patch.patch_addr + j;
@@ -498,7 +601,19 @@ comp_map(struct Compartment* to_map)
     }
 
     // Inject manager transfer function
-    memcpy((void*) to_map->mng_trans_fn, &compartment_transition_out, to_map->mng_trans_fn_sz);
+    memcpy(to_map->mng_trans_fn, (void*) &compartment_transition_out, to_map->mng_trans_fn_sz);
+
+    // Bind `.got.plt` entries
+    for (size_t i = 0; i < to_map->rela_maps_count; ++i)
+    {
+        if (to_map->rela_maps[i].rela_address == 0)
+        {
+            continue;
+        }
+        memcpy((void*) to_map->rela_maps[i].rela_address,
+               &to_map->rela_maps[i].target_func_address,
+               sizeof(void*));
+    }
 
     to_map->mapped = true;
 }
@@ -535,14 +650,12 @@ comp_exec(struct Compartment* to_exec, char* fn_name, void* args, size_t args_co
     }
     if (!fn)
     {
-    printf("Did not find entry point `%s`!\n", fn_name);
-    assert(false);
+        errx(1, "Did not find entry point `%s`!\n", fn_name);
     }
     void* wrap_sp;
 
-    // TODO check if we still need this
+    // TODO check if we need anything from here
     // https://git.morello-project.org/morello/kernel/linux/-/wikis/Morello-pure-capability-kernel-user-Linux-ABI-specification
-    /*setup_stack(to_exec);*/
 
     int64_t result;
 
@@ -558,8 +671,8 @@ comp_exec(struct Compartment* to_exec, char* fn_name, void* args, size_t args_co
         /*arg = cheri_perms_and(arg, !(CHERI_PERM_STORE | CHERI_PERM_EXECUTE));*/
         /*args_caps[i] = arg;*/
     /*}*/
-    result = comp_exec_in((void*) to_exec->stack_pointer, to_exec->ddc, fn, args, args_count);
-
+    result = comp_exec_in((void*) to_exec->stack_pointer, to_exec->ddc, fn,
+                          args, args_count, sealed_redirect_cap);
     return result;
 }
 
@@ -569,151 +682,293 @@ comp_clean(struct Compartment* to_clean)
     close(to_clean->fd);
     if (to_clean->mapped)
     {
-        for (size_t i = 0; i < to_clean->seg_count; ++i)
-        {
-            free(to_clean->segs[i]);
-            // TODO unmap
-        }
+        // TODO unmap
     }
     else if (to_clean->mapped_full)
     {
         // TODO unmap
     }
+
+    for (size_t i = 0; i < to_clean->seg_count; ++i)
+    {
+        free(to_clean->segs[i]);
+    }
+    free(to_clean->segs);
+
     for (size_t i = 0; i < to_clean->entry_point_count; ++i)
     {
         free((char*) to_clean->comp_fns[i]->fn_name);
         free(to_clean->comp_fns[i]);
     }
+
+    for (size_t i = 0; i < to_clean->rela_maps_count; ++i)
+    {
+        free(to_clean->rela_maps[i].rela_name);
+    }
+    free(to_clean->rela_maps);
+
+    struct LibDependency* ld;
+    for (size_t i = 0; i < to_clean->lib_deps_count; ++i)
+    {
+        ld = to_clean->lib_deps[i];
+        free(ld->lib_name);
+        free(ld->lib_path);
+        for (size_t j = 0; j < ld->lib_segs_count; ++j)
+        {
+            free(ld->lib_segs[j]);
+        }
+        free(ld->lib_segs);
+        for (size_t j = 0; j < ld->lib_syms_count; ++j)
+        {
+            free(ld->lib_syms[j].sym_name);
+        }
+        free(ld->lib_syms);
+        free(ld);
+    }
+    free(to_clean->lib_deps);
+    free(to_clean->intercept_patches);
+
+
     free(to_clean);
     // TODO
-}
-
-void
-log_new_comp(struct Compartment* to_log)
-{
-    comps = realloc(comps, sizeof(comps) + sizeof(struct Compartment));
-    comps[to_log->id] = to_log;
-}
-
-struct Compartment*
-find_comp_by_addr(void* to_find)
-{
-    assert(comps[0]->base <= (uintptr_t) to_find);
-    assert(comps[0]->base + comps[0]->size > (uintptr_t) to_find);
-    return comps[0]; // TODO
 }
 
 /*******************************************************************************
  * Helper functions
  ******************************************************************************/
 
-/* TODO
- * WIP attempt to set the stack correctly upon entering the compartment
- * executable. This is related to `argv` and `envp` stack setup for normal
- * binary executions. Might be needed for argument passing, and is related to
- * vDSO loosely.
- *
- * Morello reference:
- * https://git.morello-project.org/morello/kernel/linux/-/wikis/Morello-pure-capability-kernel-user-Linux-ABI-specification#arguments-argv-and-environment-variables-envp
- */
-/*void*/
-/*setup_stack(struct Compartment* to_setup)*/
-/*{*/
-    /*assert(to_setup->stack_pointer % 16 == 0);*/
-
-    /*uintptr_t init_sp = to_setup->stack_pointer;*/
-    /*uintptr_t argv_ptrs[to_setup->argc];*/
-    /*for (size_t i = 0; i < to_setup->argc; ++i)*/
-    /*{*/
-        /*comp_stack_push(to_setup, to_setup->argv[i], strlen(to_setup->argv[i]));*/
-        /*argv_ptrs[i] = to_setup->stack_pointer;*/
-    /*}*/
-
-    /*uintptr_t envp_ptrs[ENV_FIELDS_CNT];*/
-    /*const char* envp_val;*/
-    /*for (size_t i = 0; i < ENV_FIELDS_CNT; ++i)*/
-    /*{*/
-        /*envp_val = get_env_str(comp_env_fields[i]);*/
-        /*comp_stack_push(to_setup, envp_val, strlen(envp_val));*/
-        /*envp_ptrs[i] = to_setup->stack_pointer;*/
-    /*}*/
-
-    /*size_t stack_push_size = (1 + 1 + 1 + sizeof(envp_ptrs) + sizeof(argv_ptrs)) * sizeof(uint64_t);*/
-    /*void* null_delim = NULL;*/
-    /*[> argc <]*/
-    /*size_t stack_argc = to_setup->argc;*/
-    /*comp_stack_push(to_setup, &stack_argc, sizeof(uint64_t));*/
-    /*[> argv <]*/
-    /*for (size_t i = 0; i < to_setup->argc; ++i)*/
-    /*{*/
-        /*comp_stack_push(to_setup, (void*) &argv_ptrs[i], sizeof(uint64_t));*/
-    /*}*/
-    /*[> argv NULL delimiter <]*/
-    /*comp_stack_push(to_setup, &null_delim, sizeof(null_delim));*/
-    /*[> envp <]*/
-    /*for (size_t i = 0; i < ENV_FIELDS_CNT; ++i) // envp*/
-    /*{*/
-        /*[>comp_stack_push(comp_envs[i], strlen(comp_envs[1] + 1);<]*/
-        /*comp_stack_push(to_setup, (void*) &envp_ptrs[i], sizeof(uint64_t));*/
-    /*}*/
-    /*[> envp NULL delimiter <]*/
-    /*comp_stack_push(to_setup, &null_delim, sizeof(null_delim));*/
-    /*[> auxv <]*/
-    /*comp_stack_auxval_push(to_setup, AT_PAGESZ, elf_aux_info(AT_PAGESZ, NULL, sizeof(size_t)));*/
-    /*comp_stack_auxval_push(to_setup, AT_PHDR, to_setup->phdr);*/
-    /*comp_stack_auxval_push(to_setup, AT_PHENT, to_setup->phentsize);*/
-    /*comp_stack_auxval_push(to_setup, AT_PHNUM, to_setup->phnum);*/
-    /*[>comp_stack_auxval_push(to_setup, AT_SECURE, 0);<]*/
-    /*[>comp_stack_auxval_push(to_setup, AT_RANDOM, rand());<]*/
-    /*comp_stack_auxval_push(to_setup, AT_NULL, 0);*/
-
-    /*to_setup->stack_pointer = init_sp;*/
-
-/*}*/
-
-/*******************************************************************************
- * Print functions
- * TODO complete these once structs stabilize
- ******************************************************************************/
-
-void
-comp_print(struct Compartment* to_print)
+static
+ssize_t
+do_pread(int fd, void* buf, size_t count, off_t offset)
 {
-    printf("=== COMPARTMENT ===\n");
-    printf("\t * ID        --- %lu\n", to_print->id);
-    printf("\t * FD        --- %d\n", to_print->fd);
-
-    printf("\t * PHDR      --- %hu\n", to_print->phdr);
-    /*printf("\t * DDC       --- %lu\n", to_print->ddc);*/
-
-    printf("\t * SIZE      --- %lu\n", to_print->size);
-    printf("\t * BASE      --- %#010x\n", (unsigned int) to_print->base);
-    printf("\t * ENTRY CNT --- %lu\n", to_print->entry_point_count);
-    printf("\t * MAPD      --- %d\n", to_print->mapped);
-    printf("\t * MAPDF     --- %d\n", to_print->mapped_full);
-
-    /*printf("\t * ENTRY   --- %#010x\n", (unsigned int) to_print->entry_point);*/
-    printf("\t * RELACNT   --- %lu\n", to_print->relas_cnt);
-    printf("\t * SEGC      --- %lu\n", to_print->seg_count);
-    printf("\t * SEGS      --- ");
-    for (size_t i = 0; i < to_print->seg_count; ++i)
+    size_t res = pread(fd, buf, count, offset);
+    if (res == -1)
     {
-        printf("%p, ", to_print->segs[i]);
+        err(1, "Error in pread");
     }
-    printf("\n");
-    printf("\t * SEGSZ   --- %lu\n", to_print->segs_size);
-    printf("\t * PGSZ    --- %lu\n", to_print->page_size);
+    return res;
 }
 
-void
-segmap_print(struct SegmentMap* to_print)
+static
+Elf64_Sym*
+find_symbols(const char** names, size_t names_to_find_count, bool find_all,
+             Elf64_Sym* symtb, char* strtb, size_t symtb_sz)
 {
-    printf("=== SEGMENT MAP ===\n");
-    printf("\t * BOT  --- %#010x\n", (unsigned int) to_print->mem_bot);
-    printf("\t * TOP  --- %#010x\n", (unsigned int) to_print->mem_top);
-    printf("\t * OFF  --- %zu\n", to_print->offset);
-    printf("\t * M_SZ --- %zu\n", to_print->mem_sz);
-    printf("\t * F_SZ --- %zu\n", to_print->file_sz);
-    printf("\t * CORR --- %zu\n", to_print->correction);
-    printf("\t * FLAG --- %d\n", to_print->prot_flags);
+    Elf64_Sym* found_syms = calloc(names_to_find_count, sizeof(Elf64_Sym));
+    Elf64_Sym curr_sym;
+    size_t found_syms_count = 0;
+    for (size_t i = 0; i < symtb_sz / sizeof(Elf64_Sym); ++i)
+    {
+        curr_sym = symtb[i];
+        for (size_t j = 0; j < names_to_find_count; ++j)
+        {
+            // XXX As a follow-up from how we handle the string table, here we
+            // get symbol names by indexing at the `char` offset, then getting
+            // the string pointer (equivalent to `strtb + curr_sym.st_name`).
+            if (!strcmp(names[j], &strtb[curr_sym.st_name]))
+            {
+                found_syms[j] = curr_sym;
+                found_syms_count += 1;
+            }
+        }
+    }
+
+    // If we didn't find all symbols that we wanted to intercept, throw an error
+    if (find_all && found_syms_count != names_to_find_count)
+    {
+        const char** not_found_syms = malloc(names_to_find_count);
+        size_t not_found_idx = 0;
+        for (size_t i = 0; i < names_to_find_count; ++i)
+        {
+            bool not_found = true;
+            for (size_t j = 0; j < found_syms_count; ++j)
+            {
+                if (!strcmp(&strtb[found_syms[j].st_name], names[i]))
+                {
+                    not_found = false;
+                    break;
+                }
+            }
+            if (not_found)
+            {
+                not_found_syms[not_found_idx] = names[i];
+                not_found_idx += 1;
+            }
+        }
+        printf("Did not find following entry points [ ");
+        for (size_t i = 0; i < not_found_idx; ++i)
+        {
+            printf("%s ", not_found_syms[i]);
+        }
+        printf("]\n");
+        free(not_found_syms);
+        free(found_syms);
+        errx(1, NULL);
+    }
+
+    return found_syms;
+}
+
+static
+char*
+find_in_dir(const char* lib_name, char* search_dir)
+{
+    errno = 0;
+    char** search_paths = malloc(sizeof(char*));
+    search_paths[0] = search_dir;
+    FTS* dir = fts_open(search_paths, FTS_LOGICAL, NULL);
+    if (!dir)
+    {
+        err(1, "Failed fts_open for path %s.\n", search_dir);
+    }
+
+    FTSENT* curr_entry;
+    while ((curr_entry = fts_read(dir)) != NULL)
+    {
+        if (!strcmp(lib_name, curr_entry->fts_name))
+        {
+            return curr_entry->fts_path;
+        }
+    }
+    fts_close(dir);
+    free(search_paths);
+    return NULL;
+}
+
+static
+void
+init_comp_scratch_mem(struct Compartment* new_comp)
+{
+    new_comp->scratch_mem_base =
+        align_up(
+            (char*) new_comp->segs[new_comp->seg_count - 1]->mem_top +
+                new_comp->page_size,
+            new_comp->page_size);
+    new_comp->max_manager_caps_count = 10; // TODO
+    new_comp->scratch_mem_heap_size = 0x800000UL; // TODO
+    new_comp->scratch_mem_size =
+            new_comp->scratch_mem_heap_size +
+            new_comp->max_manager_caps_count * sizeof(void* __capability) +
+            new_comp->mng_trans_fn_sz;
+    new_comp->scratch_mem_alloc = 0;
+    new_comp->scratch_mem_stack_top =
+        align_down(
+            (char*) new_comp->scratch_mem_base +
+                new_comp->scratch_mem_heap_size,
+            16);
+    new_comp->scratch_mem_stack_size = 0x80000UL; // TODO
+    new_comp->manager_caps = new_comp->scratch_mem_stack_top;
+    new_comp->active_manager_caps_count = 0;
+    new_comp->mng_trans_fn =
+        (char*) new_comp->manager_caps +
+        new_comp->max_manager_caps_count * sizeof(void* __capability);
+
+    assert(((uintptr_t) new_comp->scratch_mem_base) % 16 == 0);
+    assert((((uintptr_t) new_comp->scratch_mem_base) + new_comp->scratch_mem_size) % 16 == 0);
+    assert(((uintptr_t) new_comp->scratch_mem_stack_top) % 16 == 0);
+    assert(
+        (((uintptr_t) new_comp->scratch_mem_stack_top) -
+            new_comp->scratch_mem_stack_size) % 16 == 0);
+    assert(new_comp->scratch_mem_size % 16 == 0);
+}
+
+/* Get the segment data for segments we will be mapping for a library dependency
+ */
+static
+void
+init_lib_dep_info(struct LibDependency* lib_dep, struct Compartment* new_comp)
+{
+    lib_dep->lib_segs_count = 0;
+    int lib_fd = open(lib_dep->lib_path, O_RDONLY);
+    assert(lib_fd != -1 && "Error opening `lib_fd`");
+    Elf64_Ehdr lib_ehdr;
+    Elf64_Phdr lib_phdr;
+    do_pread(lib_fd, &lib_ehdr, sizeof(Elf64_Ehdr), 0);
+
+    // Get segment data
+    for (size_t i = 0; i < lib_ehdr.e_phnum; ++i)
+    {
+        do_pread((int) lib_fd, &lib_phdr, sizeof(Elf64_Phdr),
+                 lib_ehdr.e_phoff + i * sizeof(lib_phdr));
+        if (lib_phdr.p_type != PT_LOAD)
+        {
+            continue;
+        }
+
+        struct SegmentMap* this_seg = malloc(sizeof(struct SegmentMap));
+        this_seg->mem_bot = (void*) align_down(lib_phdr.p_vaddr, new_comp->page_size);
+        this_seg->correction = (char*) lib_phdr.p_vaddr - (char*) this_seg->mem_bot;
+        this_seg->mem_top = (char*) lib_phdr.p_vaddr + lib_phdr.p_memsz;
+        this_seg->offset = align_down(lib_phdr.p_offset, new_comp->page_size);
+        this_seg->mem_sz = lib_phdr.p_memsz + this_seg->correction;
+        this_seg->file_sz = lib_phdr.p_filesz + this_seg->correction;
+        this_seg->prot_flags = (lib_phdr.p_flags & PF_R ? PROT_READ : 0) |
+                                (lib_phdr.p_flags & PF_W ? PROT_WRITE : 0) |
+                                (lib_phdr.p_flags & PF_X ? PROT_EXEC : 0);
+
+        lib_dep->lib_segs_count += 1;
+        lib_dep->lib_segs_size += align_up(this_seg->mem_sz, lib_phdr.p_align); // TODO check
+        lib_dep->lib_segs =
+            realloc(lib_dep->lib_segs,
+                    lib_dep->lib_segs_count * sizeof(struct SegmentMap));
+        lib_dep->lib_segs[lib_dep->lib_segs_count - 1] = this_seg;
+    }
+
+    lib_dep->lib_mem_base =
+        align_down((char*) new_comp->mem_top + new_comp->page_size, new_comp->page_size);
+    new_comp->size += new_comp->page_size + lib_dep->lib_segs_size;
+
+    // Get symbol table
+    Elf64_Shdr curr_shdr;
+    Elf64_Shdr link_shdr;
+    Elf64_Sym curr_sym;
+    for (size_t i = 0; i < lib_ehdr.e_shnum; ++i)
+    {
+        do_pread((int) lib_fd, &curr_shdr, sizeof(Elf64_Shdr),
+                 lib_ehdr.e_shoff + i * sizeof(Elf64_Shdr));
+        if (curr_shdr.sh_type != SHT_SYMTAB)
+        {
+            continue;
+        }
+
+        assert(curr_shdr.sh_link);
+        do_pread((int) lib_fd, &link_shdr, sizeof(Elf64_Shdr),
+                 lib_ehdr.e_shoff + curr_shdr.sh_link * sizeof(Elf64_Shdr));
+
+        Elf64_Sym* sym_tb = malloc(curr_shdr.sh_size);
+        do_pread((int) lib_fd, sym_tb, curr_shdr.sh_size, curr_shdr.sh_offset);
+        char* str_tb = malloc(link_shdr.sh_size);
+        do_pread((int) lib_fd, str_tb, link_shdr.sh_size, link_shdr.sh_offset);
+
+        lib_dep->lib_syms_count = curr_shdr.sh_size / sizeof(Elf64_Sym);
+        size_t actual_syms = 0;
+        struct LibDependencySymbol* ld_syms =
+            malloc(lib_dep->lib_syms_count * sizeof(struct LibDependencySymbol));
+        for (size_t j = 0; j < lib_dep->lib_syms_count; ++j)
+        {
+            curr_sym = sym_tb[j];
+            // TODO only handling FUNC symbols for now
+            if (ELF64_ST_TYPE(curr_sym.st_info) != STT_FUNC)
+            {
+                continue;
+            }
+            if (curr_sym.st_value == 0)
+            {
+                continue;
+            }
+            ld_syms[actual_syms].sym_offset = curr_sym.st_value;
+            char* sym_name = &str_tb[curr_sym.st_name];
+            ld_syms[actual_syms].sym_name = malloc(strlen(sym_name) + 1);
+            strcpy(ld_syms[actual_syms].sym_name, sym_name);
+            actual_syms += 1;
+        }
+        ld_syms = realloc(ld_syms, actual_syms * sizeof(struct LibDependencySymbol));
+        lib_dep->lib_syms_count = actual_syms;
+        lib_dep->lib_syms = ld_syms;
+
+        free(sym_tb);
+        free(str_tb);
+    }
+
+    close(lib_fd);
 }

--- a/src/intercept.c
+++ b/src/intercept.c
@@ -1,0 +1,172 @@
+#include "intercept.h"
+
+struct func_intercept comp_intercept_funcs[INTERCEPT_FUNC_COUNT];
+void* __capability comp_return_caps[COMP_RETURN_CAPS_COUNT];
+void* __capability sealed_redirect_cap;
+
+/* Setup required capabilities on the heap to jump from within compartments via
+ * a context switch
+ *
+ * For each function to be intercepted, we define the following:
+ * redirect_func function to be executed at a higher privilege level
+ * TODO I think the below three are common and can be lifted
+ * intercept_ddc ddc to be installed for the transition
+ * intercept_pcc
+ *      higher privileged pcc pointing to the transition support function
+ * sealed_redirect_cap
+ *      sealed capability pointing to the consecutive intercept capabilities;
+ *      this is the only component visible to the compartments
+ */
+void
+setup_intercepts()
+{
+    for (size_t i = 0; i < sizeof(to_intercept_funcs) / sizeof(to_intercept_funcs[0]); ++i)
+    {
+        comp_intercept_funcs[i].func_name = to_intercept_funcs[i].func_name;
+        comp_intercept_funcs[i].redirect_func = to_intercept_funcs[i].redirect_func;
+        comp_intercept_funcs[i].intercept_pcc =
+            cheri_address_set(cheri_pcc_get(), (uintptr_t) intercept_wrapper);
+    }
+    sealed_redirect_cap = manager_ddc;
+    sealed_redirect_cap = cheri_address_set(
+                            sealed_redirect_cap,
+                            (intptr_t) comp_return_caps);
+    asm("SEAL %[cap], %[cap], lpb\n\t"
+            : [cap]"+C"(sealed_redirect_cap)
+            : /**/ );
+    comp_return_caps[0] = manager_ddc; // TODO does this need to be sealed?
+    comp_return_caps[1] = cheri_address_set(cheri_pcc_get(), (uintptr_t) comp_exec_out);
+}
+
+/*******************************************************************************
+ * Intercept functions
+ *
+ * These functions are meant to be executed within a manager context, by
+ * intercepting certain functions within compartments which must have higher
+ * privlige
+ ******************************************************************************/
+
+time_t
+intercepted_time(time_t* t)
+{
+    return time(t);
+}
+
+/* As we are performing data compartmentalization, we must store relevant
+ * information for accessing an opened file within compartment memory. However,
+ * as we are using a bump allocator for internal memory management, we do not
+ * have the capability of `free`ing this memory. A future implementation of a
+ * better memory allocator will resolve this issue.
+ */
+FILE*
+intercepted_fopen(const char* filename, const char* mode)
+{
+    FILE* res = fopen(filename, mode);
+    assert(res != NULL);
+    /*struct Compartment* comp = manager_find_compartment_by_ddc(cheri_ddc_get()); // TODO*/
+    void* comp_addr = manager_register_mem_alloc(loaded_comp, sizeof(FILE));
+    memcpy(comp_addr, res, sizeof(FILE));
+    return comp_addr;
+}
+
+size_t
+intercepted_fread(void* __restrict buf, size_t size, size_t count, FILE* __restrict fp)
+{
+    return fread(buf, size, count, fp);
+}
+
+size_t
+intercepted_fwrite(void* __restrict buf, size_t size, size_t count, FILE* __restrict fp)
+{
+    return fwrite(buf, size, count, fp);
+}
+
+int
+intercepted_fputc(int chr, FILE* stream)
+{
+    return fputc(chr, stream);
+}
+
+int
+intercepted_fclose(FILE* fp)
+{
+    int res = fclose(fp);
+    assert(res == 0);
+    return res;
+}
+
+int
+intercepted_getc(FILE* stream)
+{
+    return getc(stream);
+}
+
+// Needed by test `lua_script`
+int
+intercepted___srget(FILE* stream)
+{
+    return __srget(stream);
+}
+
+void*
+my_realloc(void* ptr, size_t to_alloc)
+{
+    // TODO revisit this logic; do we keep a pointer in the manager of the
+    // currently loaded compartment (would probably require this to be set in
+    // the transition function), or do we get this information from the
+    // intercept source (could check the compartment mapping to see which
+    // compartment the source address comes from)
+    /*struct Compartment* comp = manager_find_compartment_by_ddc(cheri_ddc_get());*/
+    struct Compartment* comp = loaded_comp;
+
+    if (ptr == NULL)
+    {
+        return my_malloc(to_alloc); // TODO
+    }
+
+    void* new_ptr = manager_register_mem_alloc(comp, to_alloc);
+    struct mem_alloc* old_alloc = get_alloc_struct_from_ptr(comp, (uintptr_t) ptr);
+    memcpy(new_ptr, ptr, to_alloc < old_alloc->size ? to_alloc : old_alloc->size);
+    manager_free_mem_alloc(comp, ptr);
+    return new_ptr;
+}
+
+void*
+my_malloc(size_t to_alloc)
+{
+    /*struct Compartment* comp = manager_find_compartment_by_ddc(cheri_ddc_get());*/
+    struct Compartment* comp = loaded_comp;
+    assert(comp->scratch_mem_alloc + to_alloc < comp->scratch_mem_size);
+    void* new_mem = manager_register_mem_alloc(comp, to_alloc);
+    return new_mem;
+}
+
+void
+my_free(void* ptr)
+{
+    if (ptr == NULL)
+    {
+        return;
+    }
+    /*struct Compartment* comp = manager_find_compartment_by_ddc(cheri_ddc_get());*/
+    manager_free_mem_alloc(loaded_comp, ptr); // TODO
+    return;
+}
+
+int
+my_fprintf(FILE* stream, const char* format, ...)
+{
+    va_list va_args;
+    va_start(va_args, format);
+    int res = vfprintf(stream, format, va_args);
+    va_end(va_args);
+    return res;
+}
+
+size_t
+my_call_comp(size_t comp_id, char* fn_name, void* args, size_t args_count)
+{
+    struct Compartment* to_call = manager_get_compartment_by_id(comp_id);
+    return exec_comp(to_call, fn_name, args);
+    /*return exec_comp(to_call, fn_name, args, args_count);*/
+}

--- a/src/mem_mng.c
+++ b/src/mem_mng.c
@@ -13,7 +13,7 @@ void*
 manager_register_mem_alloc(struct Compartment* comp, size_t mem_size)
 {
     // TODO better algorithm to find blocks of memory available for mapping
-    void* new_mem = (void*) (comp->scratch_mem_base + comp->scratch_mem_alloc);
+    void* new_mem = (char*)comp->scratch_mem_base + comp->scratch_mem_alloc;
     struct mem_alloc* new_alloc = malloc(sizeof(struct mem_alloc));
     new_alloc->ptr = (uintptr_t) new_mem;
     new_alloc->size = mem_size;
@@ -111,6 +111,5 @@ get_alloc_struct_from_ptr(struct Compartment* comp, uintptr_t ptr)
         }
         curr_alloc = curr_alloc->next_alloc;
     }
-    printf("ERROR: Could not find allocated pointer %Pu!\n", ptr);
-    assert(false);
+    errx(1, "ERROR: Could not find allocated pointer %Pu!\n", ptr);
 }

--- a/src/transition.S
+++ b/src/transition.S
@@ -2,8 +2,10 @@
 .balign 4
 
 /* Wrapper to an intercept function, executed within a manager context;
- * required in order to maintain a consisten execution state. This also manages
+ * required in order to maintain a consistent execution state. This also manages
  * setting the `DDC` as needed.
+ *
+ * This function takes `x10` as argument, pointing to the address to jump to
  */
 .global intercept_wrapper
 .type intercept_wrapper, "function"
@@ -24,6 +26,7 @@ intercept_wrapper:
 .global compartment_transition_out
 .type compartment_transition_out, "function"
 compartment_transition_out:
+    // TODO
     stp c29, clr, [sp, #-32]!
     ldpblr c29, [c11]
     ldp c29, clr, [sp], #32
@@ -31,7 +34,8 @@ compartment_transition_out:
 compartment_transition_out_end:
 
 /* comp_exec_in(void* comp_sp, void* __capability comp_ddc, void* fn,
-                void* args, size_t args_count) */
+                void* args, size_t args_count,
+                void* __capability sealed_redirect_cap) */
 /* Instructions to enter a compartment. There is no `ret`, as we need to
  * perform a context switch upon exiting, which is done via `ldpbr`
  */
@@ -42,15 +46,15 @@ comp_exec_in:
     /  - `x19` is callee-saved, used to hold the stack pointer between
          `comp_exec_in` and `comp_exec_out`
        - `lr` is used to remember where we came from, so we can return
-       - `x29` is used for TODO???
+       - `x29` is the frame-pointer, to be restored on exit
 
        Stack layout:
-       `SP + 5 * 8` -->  ------------------
-       `SP + 4 * 8` --> |    < PADDING >   |
-       `SP + 3 * 8`   > |      old x29     |
-       `SP + 2 * 8`   > |      old LR      |
-       `SP + 1 * 8`   > | callee-saved x19 |
-       `    new SP`   >  ------------------
+       `SP + 5 * 8` -->  ---------------------
+       `SP + 4 * 8` --> |      <PADDING>      |
+       `SP + 3 * 8`   > |       old x29       |
+       `SP + 2 * 8`   > |       old  LR       |
+       `SP + 1 * 8`   > |  callee-saved  x19  |
+       `    new SP`   >  ---------------------
     */
     stp x19, lr, [sp, #-32]!
     str x29, [sp, #16]
@@ -60,8 +64,10 @@ comp_exec_in:
     mov x9, x0
     mov c10, c1
     mov x11, x2
+    mov c20, c5
 
     // Load params (only handle 3 params):
+    // TODO increase to 6
 loading_params:
     cbz  x4, loaded_params // Check if we loaded all parameters
     bl   load_param
@@ -88,12 +94,19 @@ loaded_params:
     mov x4, xzr
     mov x5, xzr
 
+    // Transition into new compartment
     mov sp, x9
     msr DDC, c10
+    // We are now fully in the new context
+
+    // Save capability needed to restore context
+    // TODO I think this should be somewhere within the compartment
+    str c20, [sp, #-32]!
+
+    // Call required function within compartment
     blr x11
 
-    adr x11, comp_return_caps
-    cvtp c11, x11
+    ldr c11, [sp]
     ldpbr c29, [c11]
 
 /* Instructions to perform once a compartment has finished execution.

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -28,7 +28,7 @@ define_property(TARGET
                 FULL_DOCS "Additional file dependencies to run a test.")
 
 # Helper functions
-function(get_deps target)
+function(get_deps target deps_var)
     set(deps_var "")
     list(APPEND deps_var $<TARGET_FILE:${target}>)
     get_property(has_config TARGET ${target} PROPERTY compartment_config SET)
@@ -43,149 +43,149 @@ function(get_deps target)
     set(deps_var ${deps_var} PARENT_SCOPE)
 endfunction()
 
-# Library test functions
-function(new_target test_name compartment)
+# Internal library tests
+function(new_func_test test_name)
     add_executable(${test_name}
         ${test_name}.c)
-    target_link_libraries(${test_name} PRIVATE chcomp dl m)
-    target_link_libraries(${test_name} PRIVATE lualib)
+    target_link_libraries(${test_name} PRIVATE chcomp)
+    target_include_directories(${test_name} PRIVATE
+        ${CMAKE_SOURCE_DIR}/src ${INCLUDE_DIR} ${TOML_INCLUDE_DIR})
+endfunction()
+
+# Compartment tests
+function(new_comp_test test_name)
+    add_library(${test_name} SHARED
+        ${test_name}.c)
+    set_target_properties(${test_name} PROPERTIES PREFIX "")
+    target_link_libraries(${test_name} PRIVATE chcomp lualib dl m)
     target_include_directories(${test_name} PRIVATE ${INCLUDE_DIR} ${LUA_INCLUDE_DIR})
-    if(${compartment})
-        target_compile_options(${test_name} PRIVATE -static)
-        if(${ARGC} GREATER 2)
-            target_link_options(${test_name} PRIVATE -static "LINKER:-image-base=${ARGV2}")
-        else()
-            target_link_options(${test_name} PRIVATE -static "LINKER:-image-base=0x1000000")
-        endif()
-        set_property(TARGET ${test_name} PROPERTY compartment TRUE)
-        if (EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/${test_name}.comp)
-            set_property(TARGET ${test_name} PROPERTY compartment_config ${CMAKE_CURRENT_SOURCE_DIR}/${test_name}.comp)
-        endif()
-    else()
-        target_link_libraries(${test_name} PRIVATE tomllib)
-        target_include_directories(${test_name} PRIVATE ${TOML_INCLUDE_DIR})
+
+    set_property(TARGET ${test_name} PROPERTY compartment TRUE)
+    if (EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/${test_name}.comp)
+        set_property(TARGET ${test_name} PROPERTY compartment_config ${CMAKE_CURRENT_SOURCE_DIR}/${test_name}.comp)
     endif()
 endfunction()
 
-function(new_test test_name test_runner test_bin)
-    if(test_bin)
-        get_deps(${test_bin})
+function(new_test test_name)
+    if(${ARGC} EQUAL "1")
+        get_property(is_comp TARGET ${test_name} PROPERTY compartment SET)
+        get_deps(${test_name} deps_var)
+        if(is_comp)
+            add_test(NAME ${test_name}
+                     COMMAND ${CMAKE_SOURCE_DIR}/tests/run_test.py
+                             manager_call
+                             --test-args $<TARGET_FILE_NAME:${test_name}>
+                             --dependencies ${deps_var}
+                     COMMAND_EXPAND_LISTS)
+        else()
+            add_test(NAME ${test_name}
+                     COMMAND ${CMAKE_SOURCE_DIR}/tests/run_test.py
+                             $<TARGET_FILE_NAME:${test_name}>
+                             --dependencies ${deps_var}
+                     COMMAND_EXPAND_LISTS)
+        endif()
+    elseif(${ARGC} GREATER_EQUAL "3")
+        set(test_bin ${ARGV1})
+        list(JOIN ARGV2 " " test_args)
+        get_property(is_comp TARGET ${test_bin} PROPERTY compartment SET)
+        get_deps(${test_bin} deps_var)
+        if(is_comp)
+            add_test(NAME ${test_name}
+                COMMAND ${CMAKE_SOURCE_DIR}/tests/run_test.py
+                        manager_args
+                        --test-args $<TARGET_FILE_NAME:${test_bin}> ${test_args}
+                        --dependencies ${deps_var}
+                COMMAND_EXPAND_LISTS)
+        else()
+            message(FATAL_ERROR "Shouldn't get here")
+        endif()
     else()
-        get_deps(${test_runner})
+        message(FATAL_ERROR "Missing arguments to test.")
     endif()
-    list(PREPEND test_cmd ${deps_var})
-    if(test_cmd)
-        list(PREPEND test_cmd "--dependencies")
-    endif()
-    if(test_bin)
-        list(PREPEND test_cmd ${ARGN})
-        list(PREPEND test_cmd ${test_bin})
-        list(PREPEND test_cmd "--test-args")
-    endif()
-    list(PREPEND test_cmd $<TARGET_FILE_NAME:${test_runner}>)
-    add_test(NAME ${test_name}
-             COMMAND ${CMAKE_SOURCE_DIR}/tests/run_test.py ${test_cmd}
-             COMMAND_EXPAND_LISTS)
 endfunction()
 
 function(new_dependency target dep_file)
     set_property(TARGET ${target} APPEND PROPERTY extra_deps ${dep_file})
 endfunction()
 
-# Binaries to build
+# Library tests
 set(func_binaries
     "test_map"
-    "test_args_near_unmapped"
-    "test_ddc_overwrite_manager"
-    "test_two_comps"
-    "test_two_comps_inter_call"
+    #"test_args_near_unmapped"
+    #"test_two_comps"
+    #"test_two_comps_inter_call"
     )
 
 set(comp_binaries
     "simple"
-    "time"
-    "lua_simple"
-    "lua_script"
+    #"time"
+    #"lua_simple"
+    #"lua_script"
     "args_simple"
-    "test_ddc_overwrite"
-    "test_two_comps-comp1"
-    "test_two_comps-comp2 0x2000000"
+    #"test_two_comps-comp1"
+    #"test_two_comps-comp2 0x2000000"
     )
 
-# Tests with no arguments
-set(tests_direct
+set(tests
+    "simple"
+    #"time"
+    #"lua_simple"
+    #"lua_script"
     "test_map"
-    "test_args_near_unmapped"
-    "test_two_comps"
-    "test_two_comps_inter_call"
-    "test_ddc_overwrite_manager"
+    #"test_args_near_unmapped"
+    #"test_two_comps"
+    #"test_two_comps_inter_call"
+    "args-simple args_simple check_simple 40 2"
+    "args-more args_simple check_simple 40 2 2 2" # Check additional arguments are ignored
+    "args-combined args_simple check_combined 400 2 20"
+    "args-negative args_simple check_negative -42"
+    "args-long-max args_simple check_llong_max 9223372036854775807"
+    "args-long-min args_simple check_llong_min -9223372036854775808"
+    "args-ulong-max args_simple check_ullong_max 18446744073709551615"
     )
 
-# Tests with arguments
-# FORMAT : <test_name> <binary> <binary_args> [...]
-set(tests_args
-    "simple manager_call simple"
-    "time manager_call time"
-    "lua_simple manager_call lua_simple"
-    "lua_script manager_call lua_script"
-    "args-simple manager_args args_simple check_simple 40 2"
-    "args-more manager_args args_simple check_simple 40 2 2 2" # Check additional arguments are ignored
-    "args-combined manager_args args_simple check_combined 400 2 20"
-    "args-negative manager_args args_simple check_negative -42"
-    "args-long-max manager_args args_simple check_llong_max 9223372036854775807"
-    "args-long-min manager_args args_simple check_llong_min -9223372036854775808"
-    "args-ulong-max manager_args args_simple check_ullong_max 18446744073709551615"
-    )
-
-#  Build targets
+# Build targets
 foreach(comp_t IN LISTS comp_binaries)
     string(FIND ${comp_t} " " space_pos)
     if(${space_pos} EQUAL -1)
-        new_target(${comp_t} TRUE)
+        new_comp_test(${comp_t} TRUE)
     else()
         string(SUBSTRING ${comp_t} 0 ${space_pos} tgt_name)
         string(SUBSTRING ${comp_t} ${space_pos} -1 img_base)
         string(STRIP ${img_base} img_base)
-        new_target(${tgt_name} TRUE ${img_base})
+        new_comp_test(${tgt_name} TRUE ${img_base})
     endif()
 endforeach()
 
 foreach(func_t IN LISTS func_binaries)
-    new_target(${func_t} FALSE)
+    new_func_test(${func_t} FALSE)
 endforeach()
-
 
 # Additional dependencies
 new_dependency(test_map $<TARGET_FILE:simple>)
-new_dependency(test_args_near_unmapped $<TARGET_FILE:args_simple>)
-new_dependency(test_args_near_unmapped ${CMAKE_CURRENT_SOURCE_DIR}/args_simple.comp)
 
-new_dependency(test_two_comps $<TARGET_FILE:test_two_comps-comp1>)
-new_dependency(test_two_comps $<TARGET_FILE:test_two_comps-comp2>)
-new_dependency(test_two_comps ${CMAKE_CURRENT_SOURCE_DIR}/test_two_comps-comp1.comp)
+#new_dependency(lua_script ${CMAKE_CURRENT_SOURCE_DIR}/hello_world.lua)
+#new_dependency(test_args_near_unmapped $<TARGET_FILE:args_simple>)
+#new_dependency(test_args_near_unmapped ${CMAKE_CURRENT_SOURCE_DIR}/args_simple.comp)
 
-new_dependency(test_two_comps_inter_call $<TARGET_FILE:test_two_comps-comp1>)
-new_dependency(test_two_comps_inter_call $<TARGET_FILE:test_two_comps-comp2>)
-new_dependency(test_two_comps_inter_call ${CMAKE_CURRENT_SOURCE_DIR}/test_two_comps-comp1.comp)
+#new_dependency(test_two_comps $<TARGET_FILE:test_two_comps-comp1>)
+#new_dependency(test_two_comps $<TARGET_FILE:test_two_comps-comp2>)
+#new_dependency(test_two_comps ${CMAKE_CURRENT_SOURCE_DIR}/test_two_comps-comp1.comp)
 
-new_dependency(test_ddc_overwrite_manager $<TARGET_FILE:test_ddc_overwrite>)
-new_dependency(test_ddc_overwrite_manager ${CMAKE_CURRENT_SOURCE_DIR}/test_ddc_overwrite.comp)
-
-new_dependency(lua_script ${CMAKE_CURRENT_SOURCE_DIR}/hello_world.lua)
-
-foreach(test_d IN LISTS tests_direct)
-    new_test(${test_d} ${test_d} "" "")
-endforeach()
+#new_dependency(test_two_comps_inter_call $<TARGET_FILE:test_two_comps-comp1>)
+#new_dependency(test_two_comps_inter_call $<TARGET_FILE:test_two_comps-comp2>)
+#new_dependency(test_two_comps_inter_call ${CMAKE_CURRENT_SOURCE_DIR}/test_two_comps-comp1.comp)
 
 # Prepare tests
-foreach(test_a IN LISTS tests_args)
-    string(REPLACE " " ";" test_args_list ${test_a})
-    list(GET test_args_list 0 test_name)
-    list(GET test_args_list 1 test_runner)
-    list(GET test_args_list 2 test_bin)
-    list(LENGTH test_args_list test_args_len)
-    if(${test_args_len} GREATER 3)
-        list(SUBLIST test_args_list 3 -1 test_bin_args)
+foreach(test_t IN LISTS tests)
+    string(REPLACE " " ";" test_t_list ${test_t})
+    list(LENGTH test_t_list test_t_len)
+    if(${test_t_len} EQUAL "1")
+        new_test(${test_t})
+    else()
+        list(GET test_t_list 0 test_name)
+        list(GET test_t_list 1 test_bin)
+        list(SUBLIST test_t_list 2 -1 test_args)
+        new_test(${test_name} ${test_bin} "${test_args}")
     endif()
-    new_test(${test_name} ${test_runner} ${test_bin} ${test_bin_args})
 endforeach()

--- a/tests/init_test.py
+++ b/tests/init_test.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+import os
+
+from fabric import Connection
+
+################################################################################
+# Constants
+################################################################################
+
+CHERIBSD_PORT = 10086
+CHERIBSD_USER = "root"
+CHERIBSD_HOST = "localhost"
+
+CHERIBSD_TEST_DIR = "testing"
+COMP_LIBRARY_PATH = "testing/libs"
+
+LOCAL_LIBS = [
+        "./third-party/lua/liblua.so",
+        ]
+REMOTE_LIBS = [
+        "/lib/libc.so.7",
+        "/usr/lib/libdl.so.1",
+        "/lib/libm.so.5",
+        ]
+
+################################################################################
+# Main
+################################################################################
+
+vm_conn = Connection(host = CHERIBSD_HOST, user = CHERIBSD_USER, port = CHERIBSD_PORT)
+
+home_dir = vm_conn.run("echo $HOME", hide = True).stdout.strip()
+CHERIBSD_TEST_DIR = os.path.join(home_dir, CHERIBSD_TEST_DIR)
+COMP_LIBRARY_PATH = os.path.join(home_dir, COMP_LIBRARY_PATH)
+remote_env = {
+        'COMP_LIBRARY_PATH': COMP_LIBRARY_PATH,
+        'LD_LIBRARY_PATH': COMP_LIBRARY_PATH,
+        }
+
+vm_conn.run(f'mkdir -p {CHERIBSD_TEST_DIR}')
+vm_conn.run(f'mkdir -p {COMP_LIBRARY_PATH}')
+for lib in LOCAL_LIBS:
+    vm_conn.put(lib, remote = f'{COMP_LIBRARY_PATH}', )
+for lib in REMOTE_LIBS:
+    cmd = f'cd {COMP_LIBRARY_PATH} ; ln -s {lib}'
+    vm_conn.run(cmd)
+vm_conn.close()

--- a/tests/manager_arg_passer.c
+++ b/tests/manager_arg_passer.c
@@ -10,8 +10,6 @@
  * but plan to move this to some configuration file in the near future
  */
 
-extern struct Compartment* loaded_comp;
-
 int
 main(int argc, char** argv)
 {
@@ -21,25 +19,13 @@ main(int argc, char** argv)
 
     assert(argc >= 4 && "Expect at least three arguments: binary file for compartment, entry function for compartment, and at least one argument to pass to compartment function.");
     char* file = argv[1];
-    size_t entry_point_count = 0;
-    struct ConfigEntryPoint* cep = parse_compartment_config(file, &entry_point_count);
-    if (!cep)
-    {
-        cep = malloc(sizeof(struct ConfigEntryPoint));
-        cep = set_default_entry_point(cep);
-    }
 
-    struct Compartment* arg_comp = comp_from_elf(file, cep, entry_point_count);
-    loaded_comp = arg_comp; // TODO
-    log_new_comp(arg_comp);
+    struct Compartment* arg_comp = register_new_comp(file, false);
     comp_map(arg_comp);
 
     char* entry_func = argv[2];
     char** entry_func_args = &argv[3];
-    struct ConfigEntryPoint comp_entry = get_entry_point(entry_func, cep, arg_comp->entry_point_count);
-    void* comp_args = prepare_compartment_args(entry_func_args, comp_entry);
-    int comp_result = comp_exec(arg_comp, entry_func, comp_args, comp_entry.arg_count);
-    clean_compartment_config(cep, arg_comp->entry_point_count);
+    int comp_result = exec_comp(arg_comp, argv[2], &argv[3]);
     comp_clean(arg_comp);
     return comp_result;
 }

--- a/tests/manager_caller.c
+++ b/tests/manager_caller.c
@@ -1,7 +1,5 @@
 #include "manager.h"
 
-extern struct Compartment* loaded_comp;
-
 int
 main(int argc, char** argv)
 {
@@ -17,18 +15,9 @@ main(int argc, char** argv)
         file += strlen(prefix);
     }
 
-    // Set default entry point with no arguments to pass
-    struct ConfigEntryPoint* main_cep = malloc(sizeof(struct ConfigEntryPoint));
-    main_cep = set_default_entry_point(main_cep);
-
-    struct Compartment* hw_comp = comp_from_elf(file, main_cep, 1);
-    loaded_comp = hw_comp; // TODO
-    log_new_comp(hw_comp);
+    struct Compartment* hw_comp = register_new_comp(file, true);
     comp_map(hw_comp);
-    int comp_result;
-    size_t comp_args_count = 0;
-    comp_result = comp_exec(hw_comp, "main", NULL, 0);
+    int comp_result = exec_comp(hw_comp, "main", NULL);
     comp_clean(hw_comp);
-    free(main_cep);
     return comp_result;
 }

--- a/tests/simple.c
+++ b/tests/simple.c
@@ -1,9 +1,11 @@
 #include <stdio.h>
-#include <time.h>
+#include <math.h>
+#include <assert.h>
 
 int
 main(void)
 {
-    time_t seconds = time(NULL);
+    assert(ceil(1.4) == 2);
+    assert(pow(2, 4) == 16);
     return 0;
 }

--- a/tests/test_args_near_unmapped.c
+++ b/tests/test_args_near_unmapped.c
@@ -10,8 +10,6 @@
  * but plan to move this to some configuration file in the near future
  */
 
-extern struct Compartment* loaded_comp;
-
 int
 main(int argc, char** argv)
 {
@@ -20,17 +18,8 @@ main(int argc, char** argv)
     setup_intercepts();
 
     char* file = "args_simple";
-    size_t entry_point_count = 0;
-    struct ConfigEntryPoint* cep = parse_compartment_config(file, &entry_point_count);
-    if (!cep)
-    {
-        cep = malloc(sizeof(struct ConfigEntryPoint));
-        cep = set_default_entry_point(cep);
-    }
 
-    struct Compartment* arg_comp = comp_from_elf(file, cep, entry_point_count);
-    loaded_comp = arg_comp; // TODO
-    log_new_comp(arg_comp);
+    struct Compartment* arg_comp = register_new_comp(file, false);
     comp_map(arg_comp);
 
     char* entry_func = "check_simple";

--- a/tests/test_map.c
+++ b/tests/test_map.c
@@ -1,21 +1,15 @@
 #include "manager.h"
+#include "compartment.c"
 
 int
-main(int argc, char** argv)
+main()
 {
     manager_ddc = cheri_ddc_get();
     setup_intercepts();
 
-    char* file = "./simple";
-
-    // Set default entry point with no arguments to pass
-    struct ConfigEntryPoint* main_cep = malloc(sizeof(struct ConfigEntryPoint));
-    main_cep = set_default_entry_point(main_cep);
-
-    struct Compartment* hw_comp = comp_from_elf(file, main_cep, 1);
-    log_new_comp(hw_comp);
+    char* file = "./simple.so";
+    struct Compartment* hw_comp = register_new_comp(file, true);
     comp_map(hw_comp);
     comp_clean(hw_comp);
-    free(main_cep);
     return 0;
 }

--- a/tests/test_two_comps.c
+++ b/tests/test_two_comps.c
@@ -1,7 +1,5 @@
 #include "manager.h"
 
-extern struct Compartment* loaded_comp;
-
 int
 main(int argc, char** argv)
 {
@@ -12,35 +10,25 @@ main(int argc, char** argv)
     char* comp_file_1 = "test_two_comps-comp1";
     char* comp_file_2 = "test_two_comps-comp2";
 
-    // Set default entry point with no arguments to pass
-    // Used for both compartments
-    struct ConfigEntryPoint* main_cep = malloc(sizeof(struct ConfigEntryPoint));
-    main_cep = set_default_entry_point(main_cep);
-
     // Load comp1
-    struct Compartment* comp1 = comp_from_elf(comp_file_1, main_cep, 1);
-    log_new_comp(comp1);
+    struct Compartment* comp1 = register_new_comp(comp_file_1, true);
     comp_map(comp1);
     fprintf(stdout, "Mapped Comp 1\n");
 
     // Load comp2
-    struct Compartment* comp2 = comp_from_elf(comp_file_2, main_cep, 1);
-    log_new_comp(comp2);
+    struct Compartment* comp2 = register_new_comp(comp_file_2, true);
     comp_map(comp2);
     fprintf(stdout, "Mapped Comp 2\n");
 
     int comp_result;
 
     // Run Comp 1
-    loaded_comp = comp1;
     comp_result = comp_exec(comp1, "main", NULL, 0);
     comp_clean(comp1);
 
     // Run Comp 2
-    loaded_comp = comp2;
     comp_result |= comp_exec(comp2, "main", NULL, 0);
     comp_clean(comp2);
 
-    free(main_cep);
     return comp_result;
 }

--- a/tests/test_two_comps_inter_call.c
+++ b/tests/test_two_comps_inter_call.c
@@ -1,7 +1,5 @@
 #include "manager.h"
 
-extern struct Compartment* loaded_comp;
-
 int
 main(int argc, char** argv)
 {
@@ -12,32 +10,22 @@ main(int argc, char** argv)
     char* comp_file_1 = "test_two_comps-comp1";
     char* comp_file_2 = "test_two_comps-comp2";
 
-    // Read entry point data for compartment 1
-    size_t ep_count = 0;
-    struct ConfigEntryPoint* comp1_cep = parse_compartment_config(comp_file_1, &ep_count);
-    struct ConfigEntryPoint* main_cep = malloc(sizeof(struct ConfigEntryPoint));
-    main_cep = set_default_entry_point(main_cep);
-
     // Load comp1
-    struct Compartment* comp1 = comp_from_elf(comp_file_1, comp1_cep, 1);
-    log_new_comp(comp1);
+    struct Compartment* comp1 = register_new_comp(comp_file_1, false);
     comp_map(comp1);
     fprintf(stdout, "Mapped Comp 1\n");
 
     // Load comp2
-    struct Compartment* comp2 = comp_from_elf(comp_file_2, main_cep, 1);
-    log_new_comp(comp2);
+    struct Compartment* comp2 = register_new_comp(comp_file_2, true);
     comp_map(comp2);
     fprintf(stdout, "Mapped Comp 2\n");
 
 
     // Run Comp 1
-    loaded_comp = comp1;
     int comp_result = comp_exec(comp1, "inter_call", NULL, 0);
     assert(comp_result == 0);
     comp_clean(comp1);
     comp_clean(comp2);
 
-    free(comp1_cep);
     return comp_result;
 }

--- a/third-party/lua.patch
+++ b/third-party/lua.patch
@@ -1,5 +1,5 @@
 diff --git a/makefile b/makefile
-index d46e650c..de080ae0 100644
+index d46e650c..42ff1904 100644
 --- a/makefile
 +++ b/makefile
 @@ -28,8 +28,8 @@ CWARNSCPP= \
@@ -13,18 +13,18 @@ index d46e650c..de080ae0 100644
  
  
  # The next warnings are neither valid nor needed for C++
-@@ -66,19 +66,17 @@ LOCAL = $(TESTS) $(CWARNS)
+@@ -66,25 +66,22 @@ LOCAL = $(TESTS) $(CWARNS)
  
  
  # enable Linux goodies
 -MYCFLAGS= $(LOCAL) -std=c99 -DLUA_USE_LINUX -DLUA_USE_READLINE
 -MYLDFLAGS= $(LOCAL) -Wl,-E
 -MYLIBS= -ldl -lreadline
-+MYCFLAGS= --config cheribsd-morello-hybrid.cfg -g $(LOCAL) -std=c99 -DLUA_USE_LINUX
-+MYLDFLAGS= --config cheribsd-morello-hybrid.cfg -g $(LOCAL) -Wl,-E
++MYCFLAGS= --config cheribsd-morello-hybrid.cfg -g -O0 $(LOCAL) -std=c99 -DLUA_USE_LINUX -DLUAI_ASSERT -fPIC
++MYLDFLAGS= --config cheribsd-morello-hybrid.cfg -g $(LOCAL) -Wl,-E -fPIC
 +MYLIBS= -ldl
  
- 
+-
 -CC= gcc
 -CFLAGS= -Wall -O2 $(MYCFLAGS) -fno-stack-protector -fno-common -march=native
 +CC?=/home/cheriworker/cheri/output/morello-sdk/bin/clang
@@ -38,3 +38,18 @@ index d46e650c..de080ae0 100644
  # == END OF USER SETTINGS. NO NEED TO CHANGE ANYTHING BELOW THIS LINE =========
  
  
+ LIBS = -lm
+ 
+-CORE_T=	liblua.a
++CORE_T=	liblua.a liblua.so
+ CORE_O=	lapi.o lcode.o lctype.o ldebug.o ldo.o ldump.o lfunc.o lgc.o llex.o \
+ 	lmem.o lobject.o lopcodes.o lparser.o lstate.o lstring.o ltable.o \
+ 	ltm.o lundump.o lvm.o lzio.o ltests.o
+@@ -110,6 +107,7 @@ a:	$(ALL_A)
+ $(CORE_T): $(CORE_O) $(AUX_O) $(LIB_O)
+ 	$(AR) $@ $?
+ 	$(RANLIB) $@
++	$(CC) -shared -ldl -Wl,-soname,liblua.so -o liblua.so $? -lm $(MYLDFLAGS)
+ 
+ $(LUA_T): $(LUA_O) $(CORE_T)
+ 	$(CC) -o $@ $(MYLDFLAGS) $(LUA_O) $(CORE_T) $(LIBS) $(MYLIBS) $(DL)


### PR DESCRIPTION
Implement support for compartments to be gives as dynamic libraries (i.e., `so` files). This includes looking for library dependencies, and loading those in the same compartment as the given user file. These libraries are expected to be found in the path given by the environment variable `COMP_LIBRARY_PATH`.

What this means is that we now also add a "local" `libc` to each compartment that needs it (likely all?). Thus, we can greatly reduce the number of intercepts we require. Perhaps we can overhaul the mechanism entirely to only intercept hard-coded functions we know we need (e.g., allocator calls).

The support for static binaries has not been removed completely, but likely has been broken due to this overhaul. Whether to leave as is, to remove completely, or to add support for it remains to be decided.

In terms of the PR, there might be scope to logically split it up. I kept the individual commits in a separate branch, to squash them into smaller commits, if need be.

Left TODOs:
* check vDSO and system calls in the new system
* fix all old tests
* consider making stack / heap of compartments dynamic sized, rather than a static hardcoded variable
* revisit logic for storing transition capabilities - I think there's something wrong there