### PR TITLE
Some renames and cleanup

### DIFF
--- a/include/compartment.h
+++ b/include/compartment.h
@@ -62,7 +62,7 @@ extern void *__capability comp_return_caps[2];
  * TODO recheck this is properly used, or re-design into a more light-weight
  * approach with pre-given transition capabilities
  */
-struct intercept_patch
+struct InterceptPatch
 {
     int *patch_addr;
     int32_t instr[INTERCEPT_INSTR_COUNT];
@@ -83,7 +83,7 @@ struct intercept_patch
 
 /* Struct representing a valid entry point to a compartment
  */
-struct entry_point
+struct CompEntryPoint
 {
     const char *fn_name;
     void *fn_addr;
@@ -153,7 +153,7 @@ struct Compartment
     size_t size; // size of compartment in memory
     void *base; // address where to load compartment
     size_t entry_point_count;
-    struct entry_point **comp_fns;
+    struct CompEntryPoint **comp_eps;
     void *mem_top;
     bool mapped;
     bool mapped_full;
@@ -170,7 +170,7 @@ struct Compartment
     void *scratch_mem_stack_top;
     size_t scratch_mem_stack_size;
     void *stack_pointer;
-    struct mem_alloc *alloc_head;
+    struct MemAlloc *alloc_head;
 
     void *manager_caps;
     size_t max_manager_caps_count;
@@ -190,7 +190,7 @@ struct Compartment
 
     // Misc
     short curr_intercept_count;
-    struct intercept_patch *intercept_patches;
+    struct InterceptPatch *intercept_patches;
 };
 
 int

--- a/include/intercept.h
+++ b/include/intercept.h
@@ -35,7 +35,7 @@ extern void *__capability sealed_redirect_cap;
 
 /* Data required to perform the transition for an intercepted function
  */
-struct func_intercept
+struct FuncIntercept
 {
     char *func_name;
     void *redirect_func;
@@ -82,7 +82,7 @@ my_fprintf(FILE *, const char *, ...);
 
 size_t
 my_call_comp(size_t, char *, void *, size_t);
-static const struct func_intercept to_intercept_funcs[] = {
+static const struct FuncIntercept to_intercept_funcs[] = {
     /* vDSO funcs */
     { "time", (void *) intercepted_time },
     /* Mem funcs */
@@ -94,6 +94,6 @@ static const struct func_intercept to_intercept_funcs[] = {
 // Functions to be intercepted and associated data
 #define INTERCEPT_FUNC_COUNT                                                   \
     sizeof(to_intercept_funcs) / sizeof(to_intercept_funcs[0])
-extern struct func_intercept comp_intercept_funcs[INTERCEPT_FUNC_COUNT];
+extern struct FuncIntercept comp_intercept_funcs[INTERCEPT_FUNC_COUNT];
 
 #endif // _INTERCEPT_H

--- a/include/manager.h
+++ b/include/manager.h
@@ -41,7 +41,7 @@ extern const char *comp_config_suffix;
  * information that we expect to appear in the compartment, as given by its
  * compartment configuration file
  */
-struct ConfigEntryPoint
+struct CompEntryPointDef
 {
     const char *name;
     size_t arg_count;
@@ -51,7 +51,7 @@ struct ConfigEntryPoint
 struct CompWithEntries
 {
     struct Compartment *comp;
-    struct ConfigEntryPoint *cep;
+    struct CompEntryPointDef *cep;
 };
 
 void *
@@ -60,24 +60,6 @@ struct Compartment *
 register_new_comp(char *, bool);
 int64_t
 exec_comp(struct Compartment *, char *, char **);
-
-struct Compartment *
-manager_find_compartment_by_addr(void *);
-struct Compartment *
-manager_find_compartment_by_ddc(void *__capability);
-struct Compartment *manager_get_compartment_by_id(size_t);
-
-// TODO stack setup when we transition into the compartment; unsure if needed,
-// but keep for now, just in case
-#define ENV_FIELDS_CNT 1
-extern const char *comp_env_fields[ENV_FIELDS_CNT];
-extern char **environ;
-const char *
-get_env_str(const char *);
-int
-manager___vdso_clock_gettime(clockid_t, struct timespec *);
-
-// END TODO
 
 union arg_holder
 {
@@ -95,7 +77,7 @@ clean_all_comps();
 void
 clean_comp(struct Compartment *);
 void
-clean_compartment_config(struct ConfigEntryPoint *, size_t);
+clean_compartment_config(struct CompEntryPointDef *, size_t);
 
 /*******************************************************************************
  * Memory allocation

--- a/include/mem_mng.h
+++ b/include/mem_mng.h
@@ -11,13 +11,13 @@
 #include "compartment.h"
 
 // TODO consider single linked list
-struct mem_alloc
+struct MemAlloc
 {
     uintptr_t ptr;
     size_t size;
 
-    struct mem_alloc *prev_alloc;
-    struct mem_alloc *next_alloc;
+    struct MemAlloc *prev_alloc;
+    struct MemAlloc *next_alloc;
 };
 
 extern size_t comp_mem_alloc;
@@ -26,10 +26,10 @@ extern size_t comp_mem_max;
 void *
 manager_register_mem_alloc(struct Compartment *, size_t);
 void
-manager_insert_new_alloc(struct Compartment *, struct mem_alloc *);
+manager_insert_new_alloc(struct Compartment *, struct MemAlloc *);
 size_t
 manager_free_mem_alloc(struct Compartment *, void *);
-struct mem_alloc *
+struct MemAlloc *
 get_alloc_struct_from_ptr(struct Compartment *, uintptr_t);
 
 #endif // MEM_MNG_H

--- a/src/intercept.c
+++ b/src/intercept.c
@@ -1,6 +1,6 @@
 #include "intercept.h"
 
-struct func_intercept comp_intercept_funcs[INTERCEPT_FUNC_COUNT];
+struct FuncIntercept comp_intercept_funcs[INTERCEPT_FUNC_COUNT];
 void *__capability comp_return_caps[COMP_RETURN_CAPS_COUNT];
 void *__capability sealed_redirect_cap;
 
@@ -131,7 +131,7 @@ my_realloc(void *ptr, size_t to_alloc)
     }
 
     void *new_ptr = manager_register_mem_alloc(comp, to_alloc);
-    struct mem_alloc *old_alloc
+    struct MemAlloc *old_alloc
         = get_alloc_struct_from_ptr(comp, (uintptr_t) ptr);
     memcpy(
         new_ptr, ptr, to_alloc < old_alloc->size ? to_alloc : old_alloc->size);

--- a/src/mem_mng.c
+++ b/src/mem_mng.c
@@ -14,7 +14,7 @@ manager_register_mem_alloc(struct Compartment *comp, size_t mem_size)
 {
     // TODO better algorithm to find blocks of memory available for mapping
     void *new_mem = (char *) comp->scratch_mem_base + comp->scratch_mem_alloc;
-    struct mem_alloc *new_alloc = malloc(sizeof(struct mem_alloc));
+    struct MemAlloc *new_alloc = malloc(sizeof(struct MemAlloc));
     new_alloc->ptr = (uintptr_t) new_mem;
     new_alloc->size = mem_size;
     manager_insert_new_alloc(comp, new_alloc);
@@ -23,7 +23,7 @@ manager_register_mem_alloc(struct Compartment *comp, size_t mem_size)
 }
 
 void
-manager_insert_new_alloc(struct Compartment *comp, struct mem_alloc *to_insert)
+manager_insert_new_alloc(struct Compartment *comp, struct MemAlloc *to_insert)
 {
     if (comp->alloc_head == NULL)
     {
@@ -42,7 +42,7 @@ manager_insert_new_alloc(struct Compartment *comp, struct mem_alloc *to_insert)
         return;
     }
 
-    struct mem_alloc *curr_alloc = comp->alloc_head;
+    struct MemAlloc *curr_alloc = comp->alloc_head;
     while (curr_alloc->next_alloc != NULL && curr_alloc->ptr < to_insert->ptr)
     {
         curr_alloc = curr_alloc->next_alloc;
@@ -65,7 +65,7 @@ manager_insert_new_alloc(struct Compartment *comp, struct mem_alloc *to_insert)
 size_t
 manager_free_mem_alloc(struct Compartment *comp, void *ptr)
 {
-    struct mem_alloc *curr_alloc = comp->alloc_head;
+    struct MemAlloc *curr_alloc = comp->alloc_head;
     while (curr_alloc != NULL && curr_alloc->ptr != (uintptr_t) ptr)
     {
         curr_alloc = curr_alloc->next_alloc;
@@ -99,10 +99,10 @@ manager_free_mem_alloc(struct Compartment *comp, void *ptr)
  * \param ptr Address to search for
  * \return A record indicating the requested memory allocation
  */
-struct mem_alloc *
+struct MemAlloc *
 get_alloc_struct_from_ptr(struct Compartment *comp, uintptr_t ptr)
 {
-    struct mem_alloc *curr_alloc = comp->alloc_head;
+    struct MemAlloc *curr_alloc = comp->alloc_head;
     while (curr_alloc->next_alloc != NULL)
     {
         if (curr_alloc->ptr == ptr)

--- a/tests/manager_caller.c
+++ b/tests/manager_caller.c
@@ -10,11 +10,6 @@ main(int argc, char **argv)
     assert(argc >= 2
         && "Expect at least one argument: binary file for compartment");
     char *file = argv[1];
-    const char *prefix = "./";
-    if (!strncmp(file, prefix, strlen(prefix)))
-    {
-        file += strlen(prefix);
-    }
 
     struct Compartment *hw_comp = register_new_comp(file, true);
     comp_map(hw_comp);


### PR DESCRIPTION
* Rename `ConfigEntryPoint` -> `CompEntryPointDef`
* `struct entry_point` > `struct CompEntryPoint`
* Rename other snake_case `struct`s to PascalCase
* `compartment->comp_fns` > `compartment->comp_eps`
* Rethink filename manipulation to get compartment config file name; should fix some potential leaks

This was originally the compartment config information parsing overhaul I wanted to do from #14, but it seems most of that has been done in #13, so it became a bit of a clean-up / rename PR.