### PR TITLE
Remove static ELF binary support

### DIFF
--- a/include/intercept.h
+++ b/include/intercept.h
@@ -83,8 +83,6 @@ my_fprintf(FILE *, const char *, ...);
 size_t
 my_call_comp(size_t, char *, void *, size_t);
 static const struct FuncIntercept to_intercept_funcs[] = {
-    /* vDSO funcs */
-    { "time", (void *) intercepted_time },
     /* Mem funcs */
     { "malloc", (void *) my_malloc },
     { "realloc", (void *) my_realloc },


### PR DESCRIPTION
Since we moved to supporting dynamic `so` ELFs, support for static ELFs has likely been broken. For code quality, we currently remove code that handle static ELFs, as well as intercepts that were introduced primarily for use with static ELFs.