### PR TITLE
Eager object symbol relocation

### DIFF
--- a/include/compartment.h
+++ b/include/compartment.h
@@ -114,6 +114,7 @@ struct LibRelaMapping
     char *rela_name;
     void *rela_address; // address of relocation in compartment
     void *target_func_address; // address of actual function
+    unsigned short rela_type;
 };
 
 /* Struct representing a symbol entry of a dependency library
@@ -122,6 +123,7 @@ struct LibDependencySymbol
 {
     char *sym_name;
     void *sym_offset;
+    unsigned short sym_type;
 };
 
 /* Struct representing the result of searching for a library symbol in a

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -122,10 +122,18 @@ set(comp_binaries
     "simple"
     "simple_libc"
     "simple_call_internal"
+    "simple_call_internal_static"
+    "simple_call_internal_weak"
     "simple_call_external"
+    "simple_static_var"
+    "simple_static_var-external"
     "simple_external"
     "simple_syscall_getpid"
     "simple_syscall_write"
+    "simple_va_args"
+    "simple_fputs"
+    "simple_printf"
+    "simple_fopen"
     #"time"
     #"lua_simple"
     #"lua_script"
@@ -138,9 +146,16 @@ set(tests
     "simple"
     "simple_libc"
     "simple_call_internal"
+    "simple_call_internal_static"
+    #"simple_call_internal_weak"
     "simple_call_external"
+    "simple_static_var"
     "simple_syscall_getpid"
     "simple_syscall_write"
+    "simple_va_args"
+    #"simple_fputs"
+    #"simple_printf"
+    "simple_fopen"
     #"time"
     #"lua_simple"
     #"lua_script"
@@ -176,9 +191,12 @@ endforeach()
 
 # Additional dependencies
 target_link_libraries(simple_call_external PRIVATE simple_external)
+new_dependency(simple_call_external $<TARGET_FILE:simple_external>)
+
+target_link_libraries(simple_static_var PRIVATE simple_static_var-external)
+new_dependency(simple_static_var $<TARGET_FILE:simple_static_var-external>)
 
 #new_dependency(test_map $<TARGET_FILE:simple>)
-new_dependency(simple_call_external $<TARGET_FILE:simple_external>)
 
 #new_dependency(lua_script ${CMAKE_CURRENT_SOURCE_DIR}/hello_world.lua)
 #new_dependency(test_args_near_unmapped $<TARGET_FILE:args_simple>)

--- a/tests/simple_call_internal_static.c
+++ b/tests/simple_call_internal_static.c
@@ -1,0 +1,16 @@
+#include <assert.h>
+#include <math.h>
+
+static int
+call_internal(int x)
+{
+    return pow(x, 2);
+}
+
+int
+main(void)
+{
+    int val = 4;
+    assert(val * val == call_internal(val));
+    return 0;
+}

--- a/tests/simple_call_internal_weak.c
+++ b/tests/simple_call_internal_weak.c
@@ -1,0 +1,12 @@
+#include <assert.h>
+#include <math.h>
+
+int __attribute__((weak)) call_internal(int x) { return pow(x, 2); }
+
+int
+main(void)
+{
+    int val = 4;
+    assert(val * val == call_internal(val));
+    return 0;
+}

--- a/tests/simple_fopen.c
+++ b/tests/simple_fopen.c
@@ -1,0 +1,38 @@
+#include <err.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+
+void
+by_fopen()
+{
+    FILE *fd = fopen("tmp", "w");
+    fprintf(fd, "Hi\n");
+    fclose(fd);
+}
+
+void
+by_syscall()
+{
+}
+
+void
+by_open()
+{
+    int fd = open("tmp", O_WRONLY | O_CREAT);
+    if (fd == -1)
+    {
+        err(1, "Error in open: ");
+    }
+    char *buf = "Hi\n";
+    write(fd, buf, strlen(buf));
+    close(fd);
+}
+
+int
+main()
+{
+    by_open();
+    return 0;
+}

--- a/tests/simple_fputs.c
+++ b/tests/simple_fputs.c
@@ -1,0 +1,12 @@
+#include <stdio.h>
+#include <unistd.h>
+
+int
+main()
+{
+    /*FILE* strem = __stdoutp;*/
+    FILE *strem = fdopen(STDOUT_FILENO, "w");
+    fputs("Hello\n", strem);
+    fclose(strem);
+    return 0;
+}

--- a/tests/simple_printf.c
+++ b/tests/simple_printf.c
@@ -1,9 +1,13 @@
 #include <stdio.h>
+#include <unistd.h>
 
 int
 main(void)
 {
+    FILE *my_stdout = fdopen(STDOUT_FILENO, "w");
     const char *hw = "Hello World!";
-    printf("Inside - %s\n", hw);
+    fprintf(my_stdout, "Inside - %s\n", hw);
+    /*printf("Inside - %s\n", hw);*/
+    fclose(my_stdout);
     return 0;
 }

--- a/tests/simple_static_var-external.c
+++ b/tests/simple_static_var-external.c
@@ -1,0 +1,1 @@
+unsigned short fortytwo = 42;

--- a/tests/simple_static_var.c
+++ b/tests/simple_static_var.c
@@ -1,0 +1,10 @@
+#include <assert.h>
+
+extern unsigned short fortytwo;
+
+int
+main()
+{
+    assert(fortytwo == 42);
+    return 0;
+}

--- a/tests/simple_va_args.c
+++ b/tests/simple_va_args.c
@@ -1,0 +1,26 @@
+#include <assert.h>
+#include <stdarg.h>
+
+int
+sum(int count, ...)
+{
+    va_list vals;
+    va_start(vals, count);
+    int acc = 0;
+    int val;
+    for (int i = 0; i < count; ++i)
+    {
+        val = va_arg(vals, int);
+        acc += val;
+    }
+    va_end(vals);
+    return acc;
+}
+
+int
+main()
+{
+    int suman = sum(3, 15, 30, -3);
+    assert(suman == 42);
+    return 0;
+}


### PR DESCRIPTION
Looking around in `printf`, we noticed it didn't work as objects were not being relocated across libraries. This PR enables this relocation; as well as adding a few extra tests.

TODOs:
* we do not properly handle GLOBAL vs LOCAL relocations; it might be a small optimization to ensure we hold the two symbol types in different containers, so that when we do relocate, we don't needlessly look around at LOCAL bound symbols;
* WEAK bound symbols aren't relocated;
* some of the added tests are currently not fully workingm mainly due to (we believe) WEAK bound symbols, which are planned to be fixed shortly.