### PR TITLE
Improve eager symbol relocation

### DIFF
--- a/include/compartment.h
+++ b/include/compartment.h
@@ -114,7 +114,8 @@ struct LibRelaMapping
     char *rela_name;
     void *rela_address; // address of relocation in compartment
     void *target_func_address; // address of actual function
-    unsigned short rela_type;
+    unsigned short rela_sym_type; // type of underlying symbol
+    unsigned short rela_sym_bind; // bind of underlying symbol
 };
 
 /* Struct representing a symbol entry of a dependency library
@@ -124,10 +125,12 @@ struct LibDependencySymbol
     char *sym_name;
     void *sym_offset;
     unsigned short sym_type;
+    unsigned short sym_bind;
 };
 
 /* Struct representing the result of searching for a library symbol in a
- * compartment
+ * compartment; for simplicity, we store the respective library index within
+ * the compartment, and symbol index within the library's symbols
  */
 struct LibSymSearchResult
 {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -147,7 +147,7 @@ set(tests
     "simple_libc"
     "simple_call_internal"
     "simple_call_internal_static"
-    #"simple_call_internal_weak"
+    "simple_call_internal_weak"
     "simple_call_external"
     "simple_static_var"
     "simple_syscall_getpid"


### PR DESCRIPTION
Previously, we were improperly distinguishing object symbols versus function symbols by looking at the type of the relocation. We now use the type of the underlying symbol to know precisely whether we're relocating an object or a function.

Furthermore, we now also consider symbol binding, in two situations:
* It is fine for a WEAK bound symbol to not have a relocation - we emit a warning when this is the case, and do relocate if a symbol is available, but some weird artifacts (e.g., `_Jv_RegisterClasses`, which seems to be some Java stuff and would do some extra work if it were to exist) do not seem to have definitions;
* We only eagerly relocate against GLOBAL bound symbols, not against LOCAL ones.