### PR TITLE
Changes to better handle relocation

### DIFF
--- a/include/compartment.h
+++ b/include/compartment.h
@@ -95,6 +95,7 @@ struct LibRelaMapping
     unsigned short rela_type; // type of relocation
     unsigned short rela_sym_type; // type of underlying symbol
     unsigned short rela_sym_bind; // bind of underlying symbol
+    uint16_t rela_sym_shndx; // section index of underlying symbol
 };
 
 /* Struct representing a symbol entry of a dependency library
@@ -115,6 +116,7 @@ struct LibSymSearchResult
 {
     unsigned short lib_idx;
     unsigned short sym_idx;
+    bool found;
 };
 
 /**
@@ -148,6 +150,9 @@ struct LibDependency
     void *tls_sec_addr;
     size_t tls_sec_size;
     size_t tls_data_size;
+    // offset from TLS base pointer (i.e., value of `tpidr_el0`) where this
+    // library's TLS variables start
+    size_t tls_offset;
 };
 
 /**
@@ -161,7 +166,6 @@ struct TLSDesc
     size_t region_size;
     void *region_start;
     unsigned short libs_count;
-    unsigned short *lib_idxs;
 };
 
 /**

--- a/src/comp_utils.c
+++ b/src/comp_utils.c
@@ -3,7 +3,7 @@
 static void *malloc_ptr;
 static size_t heap_mem_left;
 
-#define NON_COMP_DEFAULT_SIZE (1024 * 1024) // 1 GB
+#define NON_COMP_DEFAULT_SIZE (1024 * 1024 * 1024) // 1 GB
 
 void *
 malloc(size_t to_alloc)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -124,6 +124,7 @@ set(comp_binaries
     "simple_call_internal"
     "simple_call_internal_static"
     "simple_call_internal_weak"
+    "simple_const_thrloc_var"
     "simple_environ"
     "simple_external"
     "simple_fopen"
@@ -141,10 +142,15 @@ set(comp_binaries
     "simple_thrloc_var"
     "simple_thrloc_var-external"
     "simple_time"
+    "simple_toupper"
     "simple_va_args"
+    "tls_check"
+    "tls_check-external1"
+    "tls_check-external2"
 
     "lua_simple"
     "lua_script"
+    "lua_suite_some"
 
     "args_simple"
     #"test_two_comps-comp1"
@@ -157,6 +163,7 @@ set(tests
     "simple_call_internal"
     "simple_call_internal_static"
     "simple_call_internal_weak"
+    "simple_const_thrloc_var"
     "simple_environ"
     "simple_fopen"
     "simple_fputs"
@@ -170,10 +177,13 @@ set(tests
     "simple_syscall_write"
     "simple_thrloc_var"
     "simple_time"
+    #"simple_toupper"
     "simple_va_args"
+    "tls_check"
 
     "lua_simple"
     "lua_script"
+    #"lua_suite_some"
 
     "test_map"
     #"test_args_near_unmapped"
@@ -218,6 +228,10 @@ new_dependency(simple_global_var $<TARGET_FILE:simple_global_var-external>)
 
 target_link_libraries(simple_thrloc_var PRIVATE simple_thrloc_var-external)
 new_dependency(simple_thrloc_var $<TARGET_FILE:simple_thrloc_var-external>)
+
+target_link_libraries(tls_check PRIVATE tls_check-external1 tls_check-external2)
+new_dependency(tls_check $<TARGET_FILE:tls_check-external1>)
+new_dependency(tls_check $<TARGET_FILE:tls_check-external2>)
 
 new_dependency(test_map $<TARGET_FILE:simple>)
 

--- a/tests/lua_suite_some.c
+++ b/tests/lua_suite_some.c
@@ -1,0 +1,30 @@
+#include <assert.h>
+#include <string.h>
+#include <unistd.h>
+
+#include <lauxlib.h>
+#include <lua.h>
+#include <lualib.h>
+
+int
+main()
+{
+    const char *test_dir = "./lua";
+    const char *test_names[] = { "strings.lua", "calls.lua", "utf8.lua" };
+
+    lua_State *L = luaL_newstate();
+    luaL_openlibs(L);
+
+    char buf[256];
+    for (size_t i = 0; i < sizeof(test_names) / sizeof(test_names[0]); ++i)
+    {
+        snprintf(buf, sizeof(buf), "%s/%s", test_dir, test_names[i]);
+        printf(" == Running `%s`\n", buf);
+        assert(access(buf, F_OK) == 0);
+        assert(luaL_dofile(L, buf) == LUA_OK);
+    }
+
+    lua_close(L);
+
+    return 0;
+}

--- a/tests/simple_call_external.c
+++ b/tests/simple_call_external.c
@@ -1,13 +1,14 @@
 #include <assert.h>
 #include <math.h>
 
+extern const int val;
+
 int
 call_external(int);
 
 int
 main(void)
 {
-    int val = 4;
     assert(val == call_external(val));
     return 0;
 }

--- a/tests/simple_const_thrloc_var.c
+++ b/tests/simple_const_thrloc_var.c
@@ -1,0 +1,12 @@
+#include <stdio.h>
+
+_Thread_local const int *var;
+
+int
+main()
+{
+    int v = 42;
+    var = &v;
+    printf("PTR -- %p == VAR -- %d\n", (void *) var, *var);
+    return 0;
+}

--- a/tests/simple_external.c
+++ b/tests/simple_external.c
@@ -1,3 +1,5 @@
+const int val = 42;
+
 int
 call_external(int val)
 {

--- a/tests/simple_toupper.c
+++ b/tests/simple_toupper.c
@@ -1,0 +1,10 @@
+#include <ctype.h>
+#include <stdio.h>
+
+int
+main()
+{
+    char x = 'x';
+    printf("UPPER == %c\n", toupper(x));
+    return 0;
+}

--- a/tests/tls_check-external1.c
+++ b/tests/tls_check-external1.c
@@ -1,0 +1,4 @@
+_Thread_local int v;
+_Thread_local int bbb;
+static _Thread_local int x = 2424;
+static _Thread_local int y = 999;

--- a/tests/tls_check-external2.c
+++ b/tests/tls_check-external2.c
@@ -1,0 +1,6 @@
+_Thread_local int aaa;
+_Thread_local int aaaaaa;
+_Thread_local int aaaaaaaaaa;
+_Thread_local int v2;
+static _Thread_local int x2 = 4848;
+static _Thread_local int y2 = 1998;

--- a/tests/tls_check.c
+++ b/tests/tls_check.c
@@ -1,0 +1,13 @@
+#include <assert.h>
+
+extern _Thread_local int v;
+extern _Thread_local int v2;
+
+int
+main()
+{
+    v = 42;
+    v2 = 84;
+    assert(v == 42);
+    return (v - 42);
+}


### PR DESCRIPTION
* Record relocation `shndx`, so we know this is either an external, or a local symbol (improves lookup logic)
* Add function to do symbol look-up per library, than per compartment
* Fix amount of memory available in `comp_utils` when not going through a compartment
* Add some more tests (currently not working: `toupper` and `lua_suite_some`)

This should've fixed at least `toupper`, but (hopefully) it's at least a step forward.