### PR TITLE
Bug fix

### DIFF
--- a/include/compartment.h
+++ b/include/compartment.h
@@ -106,6 +106,7 @@ struct LibDependencySymbol
     void *sym_offset;
     unsigned short sym_type;
     unsigned short sym_bind;
+    uint16_t sym_shndx;
 };
 
 /* Struct representing the result of searching for a library symbol in a

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -177,7 +177,7 @@ set(tests
     "simple_syscall_write"
     "simple_thrloc_var"
     "simple_time"
-    #"simple_toupper"
+    "simple_toupper"
     "simple_va_args"
     "tls_check"
 


### PR DESCRIPTION
* Fix a bug with relocating against other external symbols
* Enable 1.33 tests (one `lua` test from the suite passing)