### PR TITLE
Memory layout improvements

### DIFF
--- a/include/compartment.h
+++ b/include/compartment.h
@@ -192,6 +192,7 @@ struct Compartment
     // Scratch memory
     void *scratch_mem_base;
     size_t scratch_mem_size;
+    size_t scratch_mem_extra;
 
     size_t scratch_mem_heap_size;
     void *scratch_mem_stack_top;
@@ -203,6 +204,7 @@ struct Compartment
     size_t entry_point_count;
     struct CompEntryPoint *entry_points;
     void *tls_lookup_func;
+    size_t total_tls_size;
     struct TLSDesc *libs_tls_sects;
 
     // Hardware info - maybe move

--- a/src/comp_utils.c
+++ b/src/comp_utils.c
@@ -96,10 +96,9 @@ malloc(size_t to_alloc)
     */
     size_t to_alloc_total = to_alloc + block_metadata_sz;
 
-    // TODO replace with return NULL and check `mem_left` works
     if (to_alloc_total > mem_left)
     {
-        errx(1, "comp_utils: Insufficient heap space left.");
+        return NULL;
     }
 
     // Find a sufficiently large block to allocate

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -133,6 +133,7 @@ set(comp_binaries
     "simple_global_var-external"
     "simple_libc"
     "simple_malloc"
+    "simple_malloc_saturate"
     "simple_open_write"
     "simple_printf"
     "simple_static_var"
@@ -170,6 +171,7 @@ set(tests
     "simple_global_var"
     "simple_libc"
     "simple_malloc"
+    "simple_malloc_saturate"
     "simple_open_write"
     "simple_printf"
     "simple_static_var"
@@ -198,6 +200,10 @@ set(tests
     "args-long-min args_simple check_llong_min -9223372036854775808"
     "args-ulong-max args_simple check_ullong_max 18446744073709551615"
     )
+
+set(tests_fail
+    "simple_malloc_saturate@Memory saturated."
+)
 
 # Build targets
 foreach(comp_t IN LISTS comp_binaries)
@@ -259,4 +265,12 @@ foreach(test_t IN LISTS tests)
         list(SUBLIST test_t_list 2 -1 test_args)
         new_test(${test_name} ${test_bin} "${test_args}")
     endif()
+endforeach()
+
+foreach(test_t IN LISTS tests_fail)
+    string(FIND ${test_t} "@" delim_pos)
+    string(SUBSTRING ${test_t} 0 ${delim_pos} test_name)
+    string(SUBSTRING ${test_t} ${delim_pos} -1 pass_regex)
+    string(SUBSTRING ${pass_regex} 1 -1 pass_regex)
+    set_property(TEST ${test_name} PROPERTY PASS_REGULAR_EXPRESSION ${pass_regex})
 endforeach()

--- a/tests/run_test.py
+++ b/tests/run_test.py
@@ -2,6 +2,7 @@
 import argparse
 import pathlib
 import os
+import sys
 
 from fabric import Connection
 
@@ -37,7 +38,7 @@ def put_file(conn, src_file):
     conn.put(src_file, remote = f'{CHERIBSD_TEST_DIR}/')
 
 def exec_cmd(conn, cmd, remote_env):
-    return conn.run(cmd, env = remote_env, echo = True)
+    return conn.run(cmd, env = remote_env, echo = True, warn = True)
 
 ################################################################################
 # Main
@@ -56,5 +57,6 @@ remote_env = {
 file_deps = [args.test, *args.dependencies]
 for dep in file_deps:
     put_file(vm_conn, dep)
-exec_cmd(vm_conn, f'cd {CHERIBSD_TEST_DIR} ; ./{args.test.name} {" ".join(args.test_args)}', remote_env)
+res = exec_cmd(vm_conn, f'cd {CHERIBSD_TEST_DIR} ; ./{args.test.name} {" ".join(args.test_args)}', remote_env)
 vm_conn.close()
+sys.exit(res.exited)

--- a/tests/simple_call_internal_weak.c
+++ b/tests/simple_call_internal_weak.c
@@ -1,7 +1,10 @@
 #include <assert.h>
 #include <math.h>
 
+// clang-format off: local clang-format seems to have diverged from CHERI one
 int __attribute__((weak)) call_internal(int x) { return pow(x, 2); }
+
+// clang-format on
 
 int
 main(void)

--- a/tests/simple_malloc.c
+++ b/tests/simple_malloc.c
@@ -8,6 +8,12 @@ check_next(void *addr, void *to_check)
     assert(*((void **) ((char *) addr - sizeof(void *))) == to_check);
 }
 
+static void
+double_val(int *v)
+{
+    *v = *v * 2;
+}
+
 int
 main(void)
 {
@@ -37,6 +43,13 @@ main(void)
     tmp01 = malloc(2 * malloc_block_sz);
     free(tmp02);
     free(tmp01);
+
+    // Check stack and heap disjointment
+    int *int01 = malloc(1 * sizeof(int));
+    *int01 = 42;
+    double_val(int01);
+    assert(*int01 == 84);
+    free(int01);
 
     // Check realloc
     void *tmp11 = realloc(NULL, 2 * malloc_block_sz);

--- a/tests/simple_malloc_saturate.c
+++ b/tests/simple_malloc_saturate.c
@@ -1,0 +1,20 @@
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+const size_t max_heap_size = 0x800000;
+const size_t malloc_block_sz = 0x10;
+
+int
+main(void)
+{
+    void *x = malloc(max_heap_size - malloc_block_sz);
+    void *y = malloc(malloc_block_sz);
+    if (y == NULL)
+    {
+        printf("Memory saturated.\n");
+    }
+
+    free(x);
+    free(y);
+}


### PR DESCRIPTION
Move around compartment scratch memory, to ensure the heap is next to the DDC boundary in the compartment. Thus, any overflows should trigger a `SIGPROT`.

Ensure compartment boundaries are as they are defined in the struct. Particularly, in `mmap`, `length` would be padded such that it would be divisible by `page_size`. This padding is now done explicitly, and additional checks are added throughout to ensure this remains consistent. This prevents the compartment scratch heap to be larger than configured in the compartment.

Further changes:
* `run_test.py` now always returns, without giving an exception
* added `simple_malloc_saturate`, which allocates all available heap memory, and then some, and expects to fail
* `malloc` in `comp_utils` now returns `NULL` when running out of memory, instead of calling `err`
* mark some code in `simple_call_internal_weak` to not be `clang-format`ted, as it seems to diverge from the CHERI version of `clang-format`