### PR TITLE
Parameterised compartments

### DIFF
--- a/include/manager.h
+++ b/include/manager.h
@@ -21,7 +21,7 @@
 #define align_up(x, align) __builtin_align_up(x, align)
 
 extern void *__capability manager_ddc;
-extern struct CompWithEntries **comps;
+extern struct Compartment **comps;
 extern struct Compartment *loaded_comp;
 
 /*******************************************************************************
@@ -30,23 +30,6 @@ extern struct Compartment *loaded_comp;
 
 // Compartment configuration file suffix
 extern const char *comp_config_suffix;
-
-/* Struct representing configuration data for one entry point; this is just
- * information that we expect to appear in the compartment, as given by its
- * compartment configuration file
- */
-struct CompEntryPointDef
-{
-    const char *name;
-    size_t arg_count;
-    char **args_type;
-};
-
-struct CompWithEntries
-{
-    struct Compartment *comp;
-    struct CompEntryPointDef *cep;
-};
 
 void *
 get_next_comp_addr(void);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -185,7 +185,7 @@ set(tests
 
     "lua_simple"
     "lua_script"
-    #"lua_suite_some"
+    "lua_suite_some"
 
     "test_map"
     #"test_args_near_unmapped"

--- a/tests/init_test.py
+++ b/tests/init_test.py
@@ -26,12 +26,12 @@ REMOTE_LIBS = [
 
 LUA_TESTS_PATH = "./third-party/lua/testes"
 LUA_TESTS = [
-        "calls.lua",
-        "goto.lua",
         "strings.lua",
+        "utf8.lua",
+        "goto.lua",
         "tpack.lua",
         "tracegc.lua",
-        "utf8.lua",
+        "calls.lua",
         ]
 
 ################################################################################

--- a/tests/lua_suite_some.c
+++ b/tests/lua_suite_some.c
@@ -10,7 +10,21 @@ int
 main()
 {
     const char *test_dir = "./lua";
-    const char *test_names[] = { "strings.lua", "calls.lua", "utf8.lua" };
+    const char *test_names[] = { "strings.lua", "utf8.lua", "goto.lua",
+        "tpack.lua", "tracegc.lua", "calls.lua" };
+    // TODO disabled due to extremely long runtime; needs profiling
+    /*const char *test_names[] = { "gc.lua" };*/
+
+    /* `lua_dofile` not returning `LUA_OK`, even without compartmentalisation
+     * api.lua
+     * attrib.lua
+     * big.lua
+     * cstack.lua
+     */
+
+    /* Internally skipped tests (needs additional testing infrastructure support
+     * for `lua`) api.c
+     */
 
     lua_State *L = luaL_newstate();
     luaL_openlibs(L);

--- a/tests/lua_suite_some.comp
+++ b/tests/lua_suite_some.comp
@@ -1,0 +1,3 @@
+[compconfig]
+heap = 0x30000000
+stack = 0x800000


### PR DESCRIPTION
Add a `CompConfig` struct, which contains parameterisable values for compartment properties. Currently this includes only the heap and stack sizes, as well as entry points. The parameters are taken from the `.comp` TOML config file, similar to how entry points are determined.

Enable `lua_suite_some` test, which runs a few hand-picked tests from the Lua test suite, just to see if we can find any other parts of Lua that need further handling in the manager.

NOTE `gc.lua` *should* work, but it seems to take 10 hours on a virtualised CHERI instance. I think it might be due to the unoptimised memory allocator implementation, but that would need further benchmarking.

Additionally refactor some old code, including getting rid of `CompEntryPoint` in favour of the singular `CompEntryPointDef` struct.