### PR TITLE
Introduce a symbols API

### DIFF
--- a/include/compartment.h
+++ b/include/compartment.h
@@ -8,7 +8,6 @@
 #include <fcntl.h>
 #include <fts.h>
 #include <limits.h>
-#include <stdbool.h>
 #include <stddef.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -17,6 +16,8 @@
 #include <sys/mman.h>
 #include <sys/stat.h>
 #include <unistd.h>
+
+#include "symbols.h"
 
 #include "cheriintrin.h"
 
@@ -94,28 +95,6 @@ struct LibRelaMapping
     uint16_t rela_sym_shndx; // section index of underlying symbol
 };
 
-/* Struct representing a symbol entry of a dependency library
- */
-struct LibDependencySymbol
-{
-    char *sym_name;
-    void *sym_offset;
-    unsigned short sym_type;
-    unsigned short sym_bind;
-    uint16_t sym_shndx;
-};
-
-/* Struct representing the result of searching for a library symbol in a
- * compartment; for simplicity, we store the respective library index within
- * the compartment, and symbol index within the library's symbols
- */
-struct LibSymSearchResult
-{
-    unsigned short lib_idx;
-    unsigned short sym_idx;
-    bool found;
-};
-
 /**
  * Struct representing a library dependency for one of our given compartments
  */
@@ -131,8 +110,7 @@ struct LibDependency
     struct SegmentMap *lib_segs;
 
     // Symbols within this library
-    size_t lib_syms_count;
-    struct LibDependencySymbol *lib_syms;
+    lib_symbol_list *lib_syms;
 
     // Library dependencies for this library
     unsigned short lib_dep_count;
@@ -224,6 +202,7 @@ struct Compartment
     void *tls_lookup_func;
     size_t total_tls_size;
     struct TLSDesc *libs_tls_sects;
+    comp_symbol_list *comp_syms;
 
     // Hardware info - maybe move
     size_t page_size;

--- a/include/symbols.h
+++ b/include/symbols.h
@@ -1,0 +1,74 @@
+#ifndef _CHERICOMP_SYMBOLS_H
+#define _CHERICOMP_SYMBOLS_H
+
+#include <err.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+struct simple_lds_list
+{
+    struct LibDependencySymbol **data;
+    size_t data_count;
+};
+
+struct simple_cs_list
+{
+    struct CompSymbol **data;
+    size_t data_count;
+};
+
+typedef struct simple_lds_list lib_symbol_list;
+typedef struct LibDependencySymbol lib_symbol;
+
+typedef struct simple_cs_list comp_symbol_list;
+typedef struct CompSymbol comp_symbol;
+
+/* Struct representing a symbol entry of a dependency library
+ */
+struct LibDependencySymbol
+{
+    char *sym_name;
+    void *sym_offset;
+    unsigned short sym_type;
+    unsigned short sym_bind;
+    uint16_t sym_shndx;
+};
+
+/* Struct representing a wrapper around a LibDependencySymbol, in order to
+ * facilitate compartment-level searching
+ */
+struct CompSymbol
+{
+    struct LibDependencySymbol *sym_ref;
+    size_t sym_lib_idx;
+};
+
+comp_symbol_list *
+comp_syms_init();
+void
+comp_syms_clean(comp_symbol_list *);
+void
+comp_syms_clean_deep(comp_symbol_list *);
+void
+comp_syms_insert(comp_symbol *, comp_symbol_list *);
+comp_symbol *
+comp_syms_search(const char *, const comp_symbol_list *);
+comp_symbol_list *
+comp_syms_find_all(const char *, const comp_symbol_list *);
+
+lib_symbol_list *
+lib_syms_init();
+void
+lib_syms_clean(lib_symbol_list *);
+void
+lib_syms_clean_deep(lib_symbol_list *);
+void
+lib_syms_insert(lib_symbol *, lib_symbol_list *);
+lib_symbol *
+lib_syms_search(const char *, const lib_symbol_list *);
+lib_symbol_list *
+lib_syms_find_all(const char *, const lib_symbol_list *);
+
+#endif // _CHERICOMP_SYMBOLS_H

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,8 +1,10 @@
 # Compartment management library
 add_library(chcomp STATIC
-    manager.c
     compartment.c
     intercept.c
+    manager.c
+    symbols_comp.c
+    symbols_lib.c
     transition.S
     )
 target_include_directories(chcomp PRIVATE ${INCLUDE_DIR} ${TOML_INCLUDE_DIR})

--- a/src/symbols_comp.c
+++ b/src/symbols_comp.c
@@ -1,0 +1,72 @@
+#include "symbols.h"
+
+/*******************************************************************************
+ * Main functions
+ ******************************************************************************/
+
+comp_symbol_list *
+comp_syms_init()
+{
+    comp_symbol_list *new_list = malloc(sizeof(comp_symbol_list));
+    new_list->data_count = 0;
+    new_list->data = NULL;
+    return new_list;
+}
+
+void
+comp_syms_clean(comp_symbol_list *list)
+{
+    free(list->data);
+    free(list);
+}
+
+void
+comp_syms_clean_deep(comp_symbol_list *list)
+{
+    for (size_t i = 0; i < list->data_count; ++i)
+    {
+        free(list->data[i]);
+    }
+    comp_syms_clean(list);
+}
+
+void
+comp_syms_insert(comp_symbol *to_insert, comp_symbol_list *list)
+{
+    size_t curr_count = list->data_count;
+    list->data = realloc(list->data, (curr_count + 1) * sizeof(comp_symbol *));
+    if (list->data == NULL)
+    {
+        err(1, "Error inserting symbol %s in comp_list!",
+            to_insert->sym_ref->sym_name);
+    }
+    list->data[curr_count] = to_insert;
+    list->data_count += 1;
+}
+
+comp_symbol *
+comp_syms_search(const char *to_find, const comp_symbol_list *list)
+{
+    for (size_t i = 0; i < list->data_count; ++i)
+    {
+        if (!strcmp(list->data[i]->sym_ref->sym_name, to_find))
+        {
+            return list->data[i];
+        }
+    }
+    errx(1, "Did not find symbol %s!\n", to_find);
+}
+
+comp_symbol_list *
+comp_syms_find_all(const char *to_find, const comp_symbol_list *list)
+{
+    comp_symbol_list *res = comp_syms_init();
+    for (size_t i = 0; i < list->data_count; ++i)
+    {
+        if (!strcmp(list->data[i]->sym_ref->sym_name, to_find))
+        {
+            comp_syms_insert(list->data[i], res);
+        }
+    }
+    return res;
+}

--- a/src/symbols_lib.c
+++ b/src/symbols_lib.c
@@ -1,0 +1,78 @@
+#include "symbols.h"
+
+static void
+lib_syms_clean_one_entry(lib_symbol *sym)
+{
+    free(sym->sym_name);
+    free(sym);
+}
+
+/*******************************************************************************
+ * Main functions
+ ******************************************************************************/
+
+lib_symbol_list *
+lib_syms_init()
+{
+    lib_symbol_list *new_list = malloc(sizeof(lib_symbol_list));
+    new_list->data_count = 0;
+    new_list->data = NULL;
+    return new_list;
+}
+
+void
+lib_syms_clean(lib_symbol_list *list)
+{
+    free(list->data);
+    free(list);
+}
+
+void
+lib_syms_clean_deep(lib_symbol_list *list)
+{
+    for (size_t i = 0; i < list->data_count; ++i)
+    {
+        lib_syms_clean_one_entry(list->data[i]);
+    }
+    lib_syms_clean(list);
+}
+
+void
+lib_syms_insert(lib_symbol *to_insert, lib_symbol_list *list)
+{
+    size_t curr_count = list->data_count;
+    list->data = realloc(list->data, (curr_count + 1) * sizeof(lib_symbol *));
+    if (list->data == NULL)
+    {
+        err(1, "Error inserting symbol %s in lib_list!", to_insert->sym_name);
+    }
+    list->data[curr_count] = to_insert;
+    list->data_count += 1;
+}
+
+lib_symbol *
+lib_syms_search(const char *to_find, const lib_symbol_list *list)
+{
+    for (size_t i = 0; i < list->data_count; ++i)
+    {
+        if (!strcmp(list->data[i]->sym_name, to_find))
+        {
+            return list->data[i];
+        }
+    }
+    errx(1, "Did not find symbol %s!\n", to_find);
+}
+
+lib_symbol_list *
+lib_syms_find_all(const char *to_find, const lib_symbol_list *list)
+{
+    lib_symbol_list *res = lib_syms_init();
+    for (size_t i = 0; i < list->data_count; ++i)
+    {
+        if (!strcmp(list->data[i]->sym_name, to_find))
+        {
+            lib_syms_insert(list->data[i], res);
+        }
+    }
+    return res;
+}


### PR DESCRIPTION
Rework how we store and search symbols for relocation, abstracting away most of the detail, in order to be able to use various underlying data types. As relocation seems to take most of the runtime based on initial observations, this is a first step in order to compare against various backend data types, rather than using an ad-hoc implementation.