### PR TITLE
Hashtable backend

### DIFF
--- a/.buildbot.sh
+++ b/.buildbot.sh
@@ -15,13 +15,16 @@ ${CLANG_FORMAT_BIN} --dry-run -Werror ${CLANG_FORMAT_SOURCES[*]}
 # Update submodules
 git submodule update --init
 
-# Apply lua patch
+# Apply `lua` patch
 lua_dir="$src_dir/third-party/lua"
 patch -d $lua_dir -i ../lua.patch
 
-# Apply toml patch
+# Apply `toml` patch
 toml_dir="$src_dir/third-party/tomlc99"
 patch -d $toml_dir -i ../tomlc99.patch
+
+# Link `tommyds` Makefile appropriately
+ln -s $(pwd)/third-party/tommyds-makefile $(pwd)/third-party/tommyds/tommyds/Makefile
 
 # Prepare python virtual env
 export PATH=$PATH:$HOME/.local/bin

--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "third-party/tomlc99"]
 	path = third-party/tomlc99
 	url = https://github.com/cktan/tomlc99
+[submodule "third-party/tommyds"]
+	path = third-party/tommyds
+	url = https://github.com/amadvance/tommyds.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,11 +48,32 @@ add_custom_target(
     toml
     DEPENDS ${TOML_LIB_PATH}
 )
-add_library(tomllib SHARED IMPORTED)
+add_library(tomllib STATIC IMPORTED)
 add_dependencies(tomllib toml)
 set_target_properties(tomllib
     PROPERTIES
     IMPORTED_LOCATION ${TOML_LIB_PATH}
+)
+
+# Build tommyds
+set(TOMMYDS_DIR ${CMAKE_SOURCE_DIR}/third-party/tommyds/tommyds)
+set(TOMMYDS_LIB ${CMAKE_SOURCE_DIR}/third-party/tommyds/tommyds/libtommyds.a)
+
+add_custom_command(
+    OUTPUT ${TOMMYDS_LIB}
+    COMMAND make
+    WORKING_DIRECTORY ${TOMMYDS_DIR}
+)
+
+add_custom_target(
+    tommyds
+    DEPENDS ${TOMMYDS_LIB}
+)
+add_library(tommydslib STATIC IMPORTED)
+add_dependencies(tommydslib tommyds)
+set_target_properties(tommydslib
+    PROPERTIES
+    IMPORTED_LOCATION ${TOMMYDS_LIB}
 )
 
 # Build sources

--- a/include/compartment.h
+++ b/include/compartment.h
@@ -17,7 +17,8 @@
 #include <sys/stat.h>
 #include <unistd.h>
 
-#include "symbols.h"
+// TODO consider re-organizing
+#include "symbols_comp.h"
 
 #include "cheriintrin.h"
 

--- a/include/symbols.h
+++ b/include/symbols.h
@@ -4,71 +4,15 @@
 #include <err.h>
 #include <stdbool.h>
 #include <stdint.h>
+#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 
-struct simple_lds_list
-{
-    struct LibDependencySymbol **data;
-    size_t data_count;
-};
+#include "tommy.h"
 
-struct simple_cs_list
-{
-    struct CompSymbol **data;
-    size_t data_count;
-};
+#define HASHTABLE_MAX_SZ 1024
+#define hashtable_hash(x) tommy_hash_u64(0, x, strlen(x))
 
-typedef struct simple_lds_list lib_symbol_list;
-typedef struct LibDependencySymbol lib_symbol;
-
-typedef struct simple_cs_list comp_symbol_list;
-typedef struct CompSymbol comp_symbol;
-
-/* Struct representing a symbol entry of a dependency library
- */
-struct LibDependencySymbol
-{
-    char *sym_name;
-    void *sym_offset;
-    unsigned short sym_type;
-    unsigned short sym_bind;
-    uint16_t sym_shndx;
-};
-
-/* Struct representing a wrapper around a LibDependencySymbol, in order to
- * facilitate compartment-level searching
- */
-struct CompSymbol
-{
-    struct LibDependencySymbol *sym_ref;
-    size_t sym_lib_idx;
-};
-
-comp_symbol_list *
-comp_syms_init();
-void
-comp_syms_clean(comp_symbol_list *);
-void
-comp_syms_clean_deep(comp_symbol_list *);
-void
-comp_syms_insert(comp_symbol *, comp_symbol_list *);
-comp_symbol *
-comp_syms_search(const char *, const comp_symbol_list *);
-comp_symbol_list *
-comp_syms_find_all(const char *, const comp_symbol_list *);
-
-lib_symbol_list *
-lib_syms_init();
-void
-lib_syms_clean(lib_symbol_list *);
-void
-lib_syms_clean_deep(lib_symbol_list *);
-void
-lib_syms_insert(lib_symbol *, lib_symbol_list *);
-lib_symbol *
-lib_syms_search(const char *, const lib_symbol_list *);
-lib_symbol_list *
-lib_syms_find_all(const char *, const lib_symbol_list *);
+#define MAX_FIND_ALL_COUNT 1024
 
 #endif // _CHERICOMP_SYMBOLS_H

--- a/include/symbols_comp.h
+++ b/include/symbols_comp.h
@@ -1,0 +1,36 @@
+#ifndef _CHERICOMP_SYMBOLS_COMP_H
+#define _CHERICOMP_SYMBOLS_COMP_H
+
+#include "symbols.h"
+#include "symbols_lib.h"
+
+typedef tommy_hashtable comp_symbol_list;
+typedef struct CompSymbol comp_symbol;
+
+/* Struct representing a wrapper around a LibDependencySymbol, in order to
+ * facilitate compartment-level searching
+ */
+struct CompSymbol
+{
+    struct LibDependencySymbol *sym_ref;
+    size_t sym_lib_idx;
+    tommy_node node;
+};
+
+comp_symbol_list *
+comp_syms_init();
+void
+comp_syms_clean(comp_symbol_list *);
+void
+comp_syms_clean_deep(comp_symbol_list *);
+void
+comp_syms_insert(comp_symbol *, comp_symbol_list *);
+comp_symbol *
+comp_syms_search(const char *, comp_symbol_list *);
+comp_symbol **
+comp_syms_find_all(const char *, comp_symbol_list *);
+
+void
+update_comp_syms(comp_symbol_list *, lib_symbol_list *, const size_t);
+
+#endif // _CHERICOMP_SYMBOLS_COMP_H

--- a/include/symbols_lib.h
+++ b/include/symbols_lib.h
@@ -1,0 +1,36 @@
+#ifndef _CHERICOMP_SYMBOLS_LIB_H
+#define _CHERICOMP_SYMBOLS_LIB_H
+
+#include "symbols.h"
+
+typedef tommy_hashtable lib_symbol_list;
+typedef struct LibDependencySymbol lib_symbol;
+
+/* Struct representing a symbol entry of a dependency library
+ */
+struct LibDependencySymbol
+{
+    char *sym_name;
+    void *sym_offset;
+    unsigned short sym_type;
+    unsigned short sym_bind;
+    uint16_t sym_shndx;
+    tommy_node node;
+};
+
+lib_symbol_list *
+lib_syms_init();
+void
+lib_syms_clean(lib_symbol_list *);
+void
+lib_syms_clean_deep(lib_symbol_list *);
+void
+lib_syms_insert(lib_symbol *, lib_symbol_list *);
+lib_symbol *
+lib_syms_search(const char *, lib_symbol_list *);
+lib_symbol **
+lib_syms_find_all(const char *, lib_symbol_list *);
+void
+lib_syms_print(lib_symbol_list *);
+
+#endif // _CHERICOMP_SYMBOLS_LIB_H

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -7,8 +7,8 @@ add_library(chcomp STATIC
     symbols_lib.c
     transition.S
     )
-target_include_directories(chcomp PRIVATE ${INCLUDE_DIR} ${TOML_INCLUDE_DIR})
-target_link_libraries(chcomp PRIVATE tomllib)
+target_include_directories(chcomp PRIVATE ${INCLUDE_DIR} ${TOML_INCLUDE_DIR} ${TOMMYDS_DIR})
+target_link_libraries(chcomp PRIVATE tomllib tommydslib)
 
 add_library(computils SHARED
     comp_utils.c)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,14 +1,16 @@
 # Manager executables
+set(BIN_INCLUDE_DIRS ${INCLUDE_DIR} ${TOML_INCLUDE_DIR} ${TOMMYDS_DIR})
+
 add_executable(manager_call
     ${TEST_DIR}/manager_caller.c
     )
-target_include_directories(manager_call PUBLIC ${INCLUDE_DIR} ${TOML_INCLUDE_DIR})
+target_include_directories(manager_call PUBLIC ${BIN_INCLUDE_DIRS})
 target_link_libraries(manager_call PUBLIC chcomp)
 
 add_executable(manager_args
     ${TEST_DIR}/manager_arg_passer.c
     )
-target_include_directories(manager_args PUBLIC ${INCLUDE_DIR} ${TOML_INCLUDE_DIR})
+target_include_directories(manager_args PUBLIC ${BIN_INCLUDE_DIRS})
 target_link_libraries(manager_args PUBLIC chcomp)
 
 # Test properties
@@ -49,7 +51,7 @@ function(new_func_test test_name)
         ${test_name}.c)
     target_link_libraries(${test_name} PRIVATE chcomp)
     target_include_directories(${test_name} PRIVATE
-        ${CMAKE_SOURCE_DIR}/src ${INCLUDE_DIR} ${TOML_INCLUDE_DIR})
+        ${CMAKE_SOURCE_DIR}/src ${BIN_INCLUDE_DIRS})
 endfunction()
 
 # Compartment tests

--- a/third-party/tommyds-makefile
+++ b/third-party/tommyds-makefile
@@ -1,0 +1,10 @@
+CFLAGS += --shared -fPIC
+
+TARGET = libtommyds.a
+SOURCES = tommy.c
+OBJECTS = $(SOURCES:.c=.o)
+
+all: $(TARGET)
+
+$(TARGET): $(OBJECTS)
+	ar rcs $@ $^


### PR DESCRIPTION
Replace the ad-hoc arrays used to handle symbols with a hash table imprementation provided by `tommyds` [1], in hopes of improving overall performance of the relocation phase.

* Add `tommyds` submodule, and integrate it with building and (hopefully) CI
* Split `symbols` files into `symbols_lib` and `symbols_comp` for more modularity
* Replace symbol storage in `symbols_*.h` with `tommyds` hashtable implementations

[1] https://www.tommyds.it/doc/index.html