### PR TITLE
Add support for Linux compilation

### DIFF
--- a/include/comp_utils.h
+++ b/include/comp_utils.h
@@ -8,7 +8,11 @@
 #include <string.h>
 #include <sys/mman.h>
 
+#ifdef __CHERI__
 #include "cheriintrin.h"
+#else
+#include "linux_harness.h"
+#endif
 
 void *malloc(size_t);
 void

--- a/include/compartment.h
+++ b/include/compartment.h
@@ -20,7 +20,9 @@
 // TODO consider re-organizing
 #include "symbols_comp.h"
 
+#ifdef __CHERI__
 #include "cheriintrin.h"
+#endif
 
 // Morello `gcc` defines `ptraddr_t` in `stddef.h`, while `clang` does so in
 // `stdint.h`
@@ -58,7 +60,8 @@ extern void *__capability comp_return_caps[2];
 // using `x` registers in `loading_params` in `transition.S`. This should be
 // the equivalent of checking for a 64-bit CHERI aware platform
 // TODO is there a better way to check?
-#if !(__LP64__ && defined(__CHERI__))
+// TODO recheck if we need this
+#if !defined(CHERI_COMP_LINUX) && !(__LP64__ && defined(__CHERI__))
 #error Expecting 64-bit Arm Morello platform
 #endif
 
@@ -211,8 +214,6 @@ struct Compartment
 
 int
 entry_point_cmp(const void *, const void *);
-struct Compartment *
-comp_init();
 struct Compartment *
 comp_from_elf(char *, struct CompConfig *); // char **, size_t, void *);
 void

--- a/include/linux_harness.h
+++ b/include/linux_harness.h
@@ -1,0 +1,38 @@
+#ifndef _COMP_LINUX_HARNESS
+#define _COMP_LINUX_HARNESS
+
+#define __capability
+
+void *
+cheri_ddc_get()
+{
+    return NULL;
+}
+
+int
+cheri_base_get(void *ddc)
+{
+    void *_ddc = ddc;
+    return 0;
+}
+
+void *
+cheri_address_get(void *ddc)
+{
+    void *_ddc = ddc;
+    return NULL;
+}
+
+intptr_t
+cheri_length_get(void *ddc)
+{
+    return cheri_base_get(ddc);
+}
+
+intptr_t
+cheri_offset_get(void *ddc)
+{
+    return cheri_base_get(ddc);
+}
+
+#endif // _COMP_LINUX_HARNESS

--- a/include/symbols_comp.h
+++ b/include/symbols_comp.h
@@ -29,6 +29,8 @@ comp_symbol *
 comp_syms_search(const char *, comp_symbol_list *);
 comp_symbol **
 comp_syms_find_all(const char *, comp_symbol_list *);
+void
+comp_syms_print(comp_symbol_list *);
 
 void
 update_comp_syms(comp_symbol_list *, lib_symbol_list *, const size_t);

--- a/src/comp_utils.c
+++ b/src/comp_utils.c
@@ -213,6 +213,10 @@ tls_lookup_stub()
 {
     // Get TLS index
     // TODO works only for one TLS region
+#ifdef __CHERI__
     asm("ldr x0, [x0, #8]" : :);
+#else
+    asm("lea -0x8(%%rbp), %%rcx" : :);
+#endif
     return;
 }

--- a/src/symbols_comp.c
+++ b/src/symbols_comp.c
@@ -74,10 +74,6 @@ comp_syms_search(const char *to_find, comp_symbol_list *list)
 {
     comp_symbol *found = tommy_hashtable_search(
         list, comp_syms_compare, to_find, hashtable_hash(to_find));
-    if (!found)
-    {
-        errx(1, "Did not find symbol %s!\n", to_find);
-    }
     return found;
 }
 
@@ -85,6 +81,11 @@ comp_symbol **
 comp_syms_find_all(const char *to_find, comp_symbol_list *list)
 {
     comp_symbol **res = calloc(MAX_FIND_ALL_COUNT, sizeof(comp_symbol *));
+    if (!res)
+    {
+        err(1,
+            "Error allocating temporary memory for compartment symbol lookup!");
+    }
     unsigned int res_sz = 0;
     tommy_hashtable_node *curr_node
         = tommy_hashtable_bucket(list, hashtable_hash(to_find));
@@ -101,6 +102,12 @@ comp_syms_find_all(const char *to_find, comp_symbol_list *list)
     assert(res_sz < MAX_FIND_ALL_COUNT - 1);
     res = realloc(res, (res_sz + 1) * sizeof(comp_symbol *));
     return res;
+}
+
+void
+comp_syms_print(comp_symbol_list *list)
+{
+    tommy_hashtable_foreach(list, comp_syms_print_one);
 }
 
 /*******************************************************************************

--- a/src/symbols_lib.c
+++ b/src/symbols_lib.c
@@ -86,6 +86,10 @@ lib_symbol **
 lib_syms_find_all(const char *to_find, lib_symbol_list *list)
 {
     lib_symbol **res = calloc(MAX_FIND_ALL_COUNT, sizeof(lib_symbol *));
+    if (!res)
+    {
+        err(1, "Error allocating temporary memory for library symbol lookup!");
+    }
     unsigned int res_sz = 0;
     tommy_hashtable_node *curr_node
         = tommy_hashtable_bucket(list, hashtable_hash(to_find));

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,6 +1,6 @@
-# Manager executables
 set(BIN_INCLUDE_DIRS ${INCLUDE_DIR} ${TOML_INCLUDE_DIR} ${TOMMYDS_DIR})
 
+# Manager executables
 add_executable(manager_call
     ${TEST_DIR}/manager_caller.c
     )
@@ -12,6 +12,22 @@ add_executable(manager_args
     )
 target_include_directories(manager_args PUBLIC ${BIN_INCLUDE_DIRS})
 target_link_libraries(manager_args PUBLIC chcomp)
+
+# Special tests
+add_executable(comp_harness EXCLUDE_FROM_ALL
+    ${SRC_DIR}/symbols_comp.c
+    ${SRC_DIR}/symbols_lib.c
+    ${TEST_DIR}/compartment_harness.c
+)
+target_include_directories(comp_harness PUBLIC ${BIN_INCLUDE_DIRS})
+target_link_libraries(comp_harness PUBLIC tomllib tommydslib)
+target_compile_options(comp_harness BEFORE PUBLIC -fsanitize=address)
+target_link_options(comp_harness BEFORE PUBLIC -fsanitize=address)
+
+add_executable(so_harness
+    ${TEST_DIR}/so_harness.c
+)
+target_link_libraries(so_harness PUBLIC dl)
 
 # Test properties
 define_property(TARGET
@@ -59,7 +75,7 @@ function(new_comp_test test_name)
     add_library(${test_name} SHARED
         ${test_name}.c)
     set_target_properties(${test_name} PROPERTIES PREFIX "")
-    target_link_libraries(${test_name} PRIVATE chcomp computils lualib dl m)
+    target_link_libraries(${test_name} PRIVATE computils lualib dl m)
     target_include_directories(${test_name} PRIVATE ${INCLUDE_DIR} ${LUA_INCLUDE_DIR})
 
     set_property(TARGET ${test_name} PROPERTY compartment TRUE)
@@ -113,7 +129,6 @@ endfunction()
 
 # Library tests
 set(func_binaries
-    "so_harness"
     "test_map"
     #"test_args_near_unmapped"
     #"test_two_comps"

--- a/tests/compartment_harness.c
+++ b/tests/compartment_harness.c
@@ -1,0 +1,66 @@
+#define ELF_ST_TYPE ELF64_ST_TYPE
+#define R_AARCH64_TLS_TPREL64 R_AARCH64_TLS_TPREL
+
+#define __capability
+
+#include <stdint.h>
+
+#define CHERI_COMP_LINUX
+
+#include "../src/compartment.c"
+
+extern char **environ;
+char **proc_env_ptr;
+void *__capability sealed_redirect_cap = NULL;
+
+// XXX Should be unused
+const unsigned short avg_sz_per_env_entry = 128;
+const unsigned short max_env_count = 128;
+const size_t max_env_sz
+    = max_env_count * sizeof(char *) + avg_sz_per_env_entry * max_env_count;
+
+int64_t
+comp_exec_in(void *comp_sp, void *__capability comp_ddc, void *fn, void *args,
+    size_t args_count, void *__capability src, void *tls)
+{
+    // Prevent `-Wno-unused-parameter` errors
+    void *_comp_sp = comp_sp;
+    void *__capability _comp_ddc = comp_ddc;
+    void *_args = args;
+    size_t _args_count = args_count;
+    void *__capability _src = src;
+    void *_tls = tls;
+
+    return (int64_t) fn;
+}
+
+int
+main(int argc, char **argv)
+{
+    if (argc < 2)
+    {
+        errx(1, "Expected at least one argument: binary file for compartment!");
+    }
+    char *file = argv[1];
+
+    proc_env_ptr = environ;
+
+    struct CompEntryPointDef *mock_cep
+        = malloc(sizeof(struct CompEntryPointDef));
+    mock_cep->name = malloc(strlen("main") + 1);
+    strcpy((char *) mock_cep->name, "main");
+    mock_cep->arg_count = 0;
+    mock_cep->args_type = NULL;
+
+    struct CompConfig *mock_cc = malloc(sizeof(struct CompConfig));
+    mock_cc->heap_size = 0x800000UL;
+    mock_cc->stack_size = 0x80000UL;
+    mock_cc->entry_points = mock_cep;
+    mock_cc->entry_point_count = 1;
+    mock_cc->base_address = (void *) 0x1000000UL;
+
+    struct Compartment *hw_comp = comp_from_elf(file, mock_cc);
+
+    comp_clean(hw_comp);
+    return 0;
+}

--- a/third-party/tommyds-makefile
+++ b/third-party/tommyds-makefile
@@ -8,3 +8,6 @@ all: $(TARGET)
 
 $(TARGET): $(OBJECTS)
 	ar rcs $@ $^
+
+clean:
+	rm $(TARGET) $(OBJECTS)


### PR DESCRIPTION
Can now compile `compartment.c` and its dependents on Linux. Added a `compartment_harness.c` file which can be used to also execute on Linux. Currently only executing the compartment data gathering (mostly reading in ELF data and doing the relocation stuff), and cleaning up. No mapping or execution happening.

Fix various bugs found during the porting process.