### PR TITLE
1 compartment to N mappings

### DIFF
--- a/include/intercept.h
+++ b/include/intercept.h
@@ -9,7 +9,9 @@
 // vDSO wrapper needed includes
 #include <time.h>
 
+#ifdef __CHERI__
 #include "cheriintrin.h"
+#endif
 
 // Forward declarations
 struct Compartment;
@@ -55,7 +57,8 @@ intercept_wrapper();
 void
 setup_intercepts();
 
-size_t
-my_call_comp(size_t, char *, void *);
+// TODO Reimplement this for inter-compartment function calls
+// size_t
+// my_call_comp(size_t, char *, void *);
 
 #endif // _INTERCEPT_H

--- a/include/manager.h
+++ b/include/manager.h
@@ -31,12 +31,8 @@ extern struct Compartment *loaded_comp;
 // Compartment configuration file suffix
 extern const char *comp_config_suffix;
 
-void *
-get_next_comp_addr(void);
 struct Compartment *
 register_new_comp(char *, bool);
-int64_t
-exec_comp(struct Compartment *, char *, char **);
 
 union arg_holder
 {
@@ -57,7 +53,24 @@ void
 clean_compartment_config(struct CompEntryPointDef *, size_t);
 
 /*******************************************************************************
- * Memory allocation
+ * Compartment mappings
  ******************************************************************************/
+
+struct CompMapping *
+mapping_new(struct Compartment *);
+struct CompMapping *
+mapping_new_fixed(struct Compartment *, void *);
+void
+mapping_free(struct CompMapping *);
+int64_t
+mapping_exec(struct CompMapping *, char *, char **);
+
+struct CompMapping
+{
+    size_t id;
+    void *__capability ddc;
+    void *map_addr;
+    struct Compartment *comp;
+};
 
 #endif // _MANAGER_H

--- a/src/intercept.c
+++ b/src/intercept.c
@@ -30,11 +30,13 @@ setup_intercepts()
         = cheri_address_set(cheri_pcc_get(), (uintptr_t) comp_exec_out);
 }
 
-size_t
-my_call_comp(
-    size_t comp_id, char *fn_name, void *args) // TODO , size_t args_count)
-{
-    struct Compartment *to_call = manager_get_compartment_by_id(comp_id);
-    return exec_comp(to_call, fn_name, args);
-    /*return exec_comp(to_call, fn_name, args, args_count);*/
-}
+// TODO Reimplement this for inter-compartment function calls
+//
+/*size_t*/
+/*my_call_comp(*/
+/*size_t comp_id, char *fn_name, void *args) // TODO , size_t args_count)*/
+/*{*/
+/*struct Compartment *to_call = manager_get_compartment_by_id(comp_id);*/
+/*return exec_comp(to_call, fn_name, args);*/
+/*[>return exec_comp(to_call, fn_name, args, args_count);<]*/
+/*}*/

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -137,6 +137,7 @@ endfunction()
 set(func_binaries
     "test_map"
     "test_map_multi"
+
     #"test_args_near_unmapped"
     #"test_two_comps"
     #"test_two_comps_inter_call"
@@ -159,6 +160,7 @@ set(comp_binaries
     "simple_malloc"
     "simple_malloc_saturate"
     "simple_open_write"
+    "simple_fprintf"
     "simple_printf"
     "simple_static_var"
     "simple_static_var-external"
@@ -197,6 +199,7 @@ set(tests
     "simple_malloc"
     "simple_malloc_saturate"
     "simple_open_write"
+    "simple_fprintf"
     "simple_printf"
     "simple_static_var"
     "simple_syscall_getpid"
@@ -209,13 +212,10 @@ set(tests
 
     "lua_simple"
     "lua_script"
-    "lua_suite_some"
+    #"lua_suite_some"
 
     "test_map"
     "test_map_multi"
-    #"test_args_near_unmapped"
-    #"test_two_comps"
-    #"test_two_comps_inter_call"
 
     "args-simple args_simple check_simple 40 2"
     "args-more args_simple check_simple 40 2 2 2" # Check additional arguments are ignored
@@ -267,16 +267,6 @@ new_dependency(tls_check $<TARGET_FILE:tls_check-external2>)
 new_dependency(test_map $<TARGET_FILE:simple>)
 
 new_dependency(lua_script ${CMAKE_CURRENT_SOURCE_DIR}/hello_world.lua)
-#new_dependency(test_args_near_unmapped $<TARGET_FILE:args_simple>)
-#new_dependency(test_args_near_unmapped ${CMAKE_CURRENT_SOURCE_DIR}/args_simple.comp)
-
-#new_dependency(test_two_comps $<TARGET_FILE:test_two_comps-comp1>)
-#new_dependency(test_two_comps $<TARGET_FILE:test_two_comps-comp2>)
-#new_dependency(test_two_comps ${CMAKE_CURRENT_SOURCE_DIR}/test_two_comps-comp1.comp)
-
-#new_dependency(test_two_comps_inter_call $<TARGET_FILE:test_two_comps-comp1>)
-#new_dependency(test_two_comps_inter_call $<TARGET_FILE:test_two_comps-comp2>)
-#new_dependency(test_two_comps_inter_call ${CMAKE_CURRENT_SOURCE_DIR}/test_two_comps-comp1.comp)
 
 # Prepare tests
 foreach(test_t IN LISTS tests)

--- a/tests/manager_arg_passer.c
+++ b/tests/manager_arg_passer.c
@@ -24,11 +24,12 @@ main(int argc, char **argv)
     char *file = argv[1];
 
     struct Compartment *arg_comp = register_new_comp(file, false);
-    comp_map(arg_comp);
+    struct CompMapping *arg_map = mapping_new(arg_comp);
 
     char *entry_func = argv[2];
     char **entry_func_args = &argv[3];
-    int comp_result = exec_comp(arg_comp, argv[2], &argv[3]);
+    int comp_result = mapping_exec(arg_map, argv[2], &argv[3]);
+    mapping_free(arg_map);
     comp_clean(arg_comp);
     return comp_result;
 }

--- a/tests/manager_caller.c
+++ b/tests/manager_caller.c
@@ -12,8 +12,9 @@ main(int argc, char **argv)
     char *file = argv[1];
 
     struct Compartment *hw_comp = register_new_comp(file, true);
-    comp_map(hw_comp);
-    int comp_result = exec_comp(hw_comp, "main", NULL);
+    struct CompMapping *hw_map = mapping_new(hw_comp);
+    int comp_result = mapping_exec(hw_map, "main", NULL);
+    mapping_free(hw_map);
     comp_clean(hw_comp);
     return comp_result;
 }

--- a/tests/manager_caller_multiple.c
+++ b/tests/manager_caller_multiple.c
@@ -18,12 +18,13 @@ main(int argc, char **argv)
     char *file = argv[1];
 
     struct Compartment *hw_comp = register_new_comp(file, true);
+    struct CompMapping *hw_map;
     int comp_result = 0;
     for (size_t i = 0; i < comps_count; ++i)
     {
-        comp_map(hw_comp);
-        comp_result = (exec_comp(hw_comp, "main", NULL) != 0) || comp_result;
-        comp_unmap(hw_comp);
+        hw_map = mapping_new(hw_comp);
+        comp_result = (mapping_exec(hw_map, "main", NULL) != 0) || comp_result;
+        mapping_free(hw_map);
     }
     comp_clean(hw_comp);
     assert(!comp_result);

--- a/tests/simple_fprintf.c
+++ b/tests/simple_fprintf.c
@@ -1,0 +1,12 @@
+#include <stdio.h>
+#include <unistd.h>
+
+int
+main(void)
+{
+    FILE *my_stdout = fdopen(STDOUT_FILENO, "w");
+    const char *hw = "Hello World!";
+    fprintf(my_stdout, "Inside - %s\n", hw);
+    fclose(my_stdout);
+    return 0;
+}

--- a/tests/simple_printf.c
+++ b/tests/simple_printf.c
@@ -4,10 +4,7 @@
 int
 main(void)
 {
-    FILE *my_stdout = fdopen(STDOUT_FILENO, "w");
-    const char *hw = "Hello World!";
-    fprintf(my_stdout, "Inside - %s\n", hw);
-    /*printf("Inside - %s\n", hw);*/
-    fclose(my_stdout);
+    printf("Inside - Hello World\n");
+    printf("Inside2 - Hello World\n");
     return 0;
 }

--- a/tests/test_map.c
+++ b/tests/test_map.c
@@ -1,6 +1,8 @@
 #include "compartment.c"
 #include "manager.h"
 
+#include <stdio.h>
+
 int
 main()
 {
@@ -9,7 +11,13 @@ main()
 
     char *file = "./simple.so";
     struct Compartment *hw_comp = register_new_comp(file, true);
-    comp_map(hw_comp);
+    printf("REG DONE\n");
+    struct CompMapping *hw_map = mapping_new(hw_comp);
+    printf("\tsz - %#zx\n", hw_comp->total_size);
+    printf("NEW DONE\n");
+    mapping_free(hw_map);
+    printf("FREE DONE\n");
     comp_clean(hw_comp);
+    printf("CLEAN DONE\n");
     return 0;
 }

--- a/tests/test_map_multi.c
+++ b/tests/test_map_multi.c
@@ -9,10 +9,12 @@ main()
 
     char *file = "./simple.so";
     struct Compartment *hw_comp = register_new_comp(file, true);
+    struct CompMapping *hw_map;
     for (size_t i = 0; i < 100; ++i)
     {
-        comp_map(hw_comp);
-        comp_unmap(hw_comp);
+        hw_map = mapping_new(hw_comp);
+        mapping_exec(hw_map, "main", NULL);
+        mapping_free(hw_map);
     }
     comp_clean(hw_comp);
     return 0;


### PR DESCRIPTION
Move from a design of "one compartment has one mapping" to "one compartment can be mapped multiple times". This involves "staging" a compartment, with temporary internal relative relocations, after which the staging can be lifted to a "mapping", which has correct relocations and can be executed. This greatly reduces the overhead of creating the same compartment multiple times.

* Remove some now unused functions