### PR TITLE
Compartment reuse

### DIFF
--- a/include/benchmarking.h
+++ b/include/benchmarking.h
@@ -1,0 +1,37 @@
+#ifndef _BENCHMARKING_COMP_H
+#define _BENCHMARKING_COMP_H
+
+#include <assert.h>
+#include <math.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+
+#define BENCH(name, func)                                                      \
+    do                                                                         \
+    {                                                                          \
+        size_t id = bench_init(name);                                          \
+        bench_start(id);                                                       \
+        func;                                                                  \
+        bench_end(id);                                                         \
+    } while (0)
+
+struct bench_entry
+{
+    const char *fn_name;
+    struct timespec start;
+    struct timespec end;
+    int res_start;
+    double diff;
+};
+
+size_t
+bench_init(const char *);
+void bench_start(size_t);
+void bench_end(size_t);
+
+void bench_report_one_id(size_t);
+
+#endif // _BENCHMARKING_COMP_H

--- a/include/comp_utils.h
+++ b/include/comp_utils.h
@@ -5,6 +5,7 @@
 #include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
+#include <stdlib.h>
 #include <string.h>
 #include <sys/mman.h>
 

--- a/include/compartment.h
+++ b/include/compartment.h
@@ -66,8 +66,8 @@ extern void *__capability comp_return_caps[2];
 #endif
 
 // Default sizes for compartment heap and stack, if not explicitly given
-#define DEFAULT_COMP_HEAP_SZ 0x800000UL // 800kB
-#define DEFAULT_COMP_STACK_SZ 0x80000UL // 80kB
+#define DEFAULT_COMP_HEAP_SZ 2 * 1024 * 1024 // 2MB
+#define DEFAULT_COMP_STACK_SZ 500 * 1024 // 500kB
 
 /* Struct representing one segment of an ELF binary.
  *
@@ -207,6 +207,8 @@ struct Compartment
     void *scratch_mem_stack_top;
     size_t scratch_mem_stack_size;
 
+    void *heap_mem_header;
+
     // Internal libraries and relocations
     size_t libs_count;
     struct LibDependency **libs;
@@ -238,5 +240,8 @@ get_seg_target(void *, struct LibDependency *, size_t);
 
 struct Compartment *
 find_comp(struct Compartment *);
+
+void
+print_comp_simple(struct Compartment *);
 
 #endif // _COMPARTMENT_H

--- a/include/manager.h
+++ b/include/manager.h
@@ -14,8 +14,10 @@
 // Third-party libraries
 #include "toml.h"
 
+#include "benchmarking.h"
 #include "compartment.h"
 #include "intercept.h"
+#include "mappings.h"
 
 #define align_down(x, align) __builtin_align_down(x, align)
 #define align_up(x, align) __builtin_align_up(x, align)
@@ -51,26 +53,5 @@ void
 clean_comp(struct Compartment *);
 void
 clean_compartment_config(struct CompEntryPointDef *, size_t);
-
-/*******************************************************************************
- * Compartment mappings
- ******************************************************************************/
-
-struct CompMapping *
-mapping_new(struct Compartment *);
-struct CompMapping *
-mapping_new_fixed(struct Compartment *, void *);
-void
-mapping_free(struct CompMapping *);
-int64_t
-mapping_exec(struct CompMapping *, char *, char **);
-
-struct CompMapping
-{
-    size_t id;
-    void *__capability ddc;
-    void *map_addr;
-    struct Compartment *comp;
-};
 
 #endif // _MANAGER_H

--- a/include/mappings.h
+++ b/include/mappings.h
@@ -1,0 +1,62 @@
+#ifndef _CHERICOMP_MAPPINGS_H
+#define _CHERICOMP_MAPPINGS_H
+
+#include <err.h>
+
+#include "compartment.h"
+
+/*******************************************************************************
+ * Compartment mappings
+ ******************************************************************************/
+
+struct CompMapping
+{
+    size_t id;
+    void *__capability ddc;
+    void *map_addr;
+    struct Compartment *comp;
+    bool in_use;
+};
+
+struct CompMapping *
+mapping_new(struct Compartment *);
+struct CompMapping *
+mapping_new_fixed(struct Compartment *, void *);
+void
+mapping_free(struct CompMapping *);
+int64_t
+mapping_exec(struct CompMapping *, char *, char **);
+
+/*******************************************************************************
+ * Mappings list
+ ******************************************************************************/
+
+#include "tommy.h"
+
+#define mapping_hash(x) tommy_inthash_u64(x)
+#define MAPPINGS_MAX_SZ 1024
+
+struct CompMappingEntry
+{
+    struct CompMapping *map_ref;
+    tommy_node node;
+};
+
+typedef tommy_hashtable mappings_list;
+typedef struct CompMappingEntry mapping_entry;
+extern mappings_list *mappings;
+
+mappings_list *
+mappings_init(void);
+void
+mappings_clean(mappings_list *);
+void
+mappings_clean_deep(mappings_list *);
+void
+mappings_insert(mapping_entry *, mappings_list *);
+struct CompMapping *
+mappings_search_free(struct Compartment *, mappings_list *);
+void
+mappings_delete(struct CompMapping *, mappings_list *);
+
+#endif // _CHERICOMP_MAPPINGS_H

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -3,6 +3,7 @@ add_library(chcomp STATIC
     compartment.c
     intercept.c
     manager.c
+    mappings.c
     symbols_comp.c
     symbols_lib.c
     transition.S
@@ -13,3 +14,8 @@ target_link_libraries(chcomp PRIVATE tomllib tommydslib)
 add_library(computils SHARED
     comp_utils.c)
 target_include_directories(computils PRIVATE ${INCLUDE_DIR})
+
+add_library(compbench SHARED
+    benchmarking.c)
+target_include_directories(compbench PRIVATE ${INCLUDE_DIR})
+target_link_libraries(compbench PRIVATE m)

--- a/src/benchmarking.c
+++ b/src/benchmarking.c
@@ -1,0 +1,79 @@
+#include <benchmarking.h>
+
+static size_t next_id = 0;
+static struct bench_entry **benchs;
+
+/*******************************************************************************
+ * Diff functions
+ ******************************************************************************/
+
+static double
+timespec_diff(struct timespec *end, struct timespec *start)
+{
+    return (end->tv_sec - start->tv_sec)
+        + (end->tv_nsec - start->tv_nsec) * pow(10, -9);
+}
+
+/*******************************************************************************
+ * Benchmark one function
+ ******************************************************************************/
+
+size_t
+bench_init(const char *fn_name)
+{
+    return 0;
+    struct bench_entry *new_be = malloc(sizeof(struct bench_entry));
+    new_be->fn_name = fn_name;
+    next_id += 1;
+    benchs = realloc(benchs, next_id * sizeof(struct bench_entry *));
+    benchs[next_id - 1] = new_be;
+    return next_id - 1;
+}
+
+void
+bench_start(size_t id)
+{
+    return;
+    benchs[id]->res_start = clock_gettime(CLOCK_MONOTONIC, &benchs[id]->start);
+}
+
+void
+bench_end(size_t id)
+{
+    return;
+    int res_end = clock_gettime(CLOCK_MONOTONIC, &benchs[id]->end);
+    assert(benchs[id]->res_start != -1);
+    assert(res_end != -1);
+    benchs[id]->diff = timespec_diff(&benchs[id]->end, &benchs[id]->start);
+    bench_report_one_id(id);
+}
+
+/*******************************************************************************
+ * Printing
+ ******************************************************************************/
+
+static void
+print_timespec(char *buf, struct timespec *ts)
+{
+    sprintf(buf, "%lld.%9ld", (long long) ts->tv_sec, ts->tv_nsec);
+}
+
+static void
+bench_report_one(struct bench_entry *entry)
+{
+
+    const unsigned short buf_sz = 30;
+    char *buf_st = alloca(buf_sz);
+    print_timespec(buf_st, &entry->start);
+    char *buf_en = alloca(buf_sz);
+    print_timespec(buf_en, &entry->end);
+    printf("Func <%s> -- start %s -- end %s -- seconds %f\n", entry->fn_name,
+        buf_st, buf_en, entry->diff);
+}
+
+void
+bench_report_one_id(size_t id)
+{
+    printf("ID %zu == ", id);
+    bench_report_one(benchs[id]);
+}

--- a/src/comp_utils.c
+++ b/src/comp_utils.c
@@ -75,7 +75,9 @@ malloc(size_t to_alloc)
                 MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
             if (mem_begin == MAP_FAILED)
             {
-                err(1, "comp_utils: Failed `mmap`");
+                exit(1);
+                /*err(1, "comp_utils: Failed `mmap`"); // TODO replace with a
+                 * signal*/
             }
             mem_left = NON_COMP_DEFAULT_SIZE;
         }
@@ -175,7 +177,9 @@ free(void *to_free)
 void *
 calloc(size_t elem_count, size_t elem_size)
 {
-    return malloc(elem_count * elem_size);
+    void *alloc = malloc(elem_count * elem_size);
+    explicit_bzero(alloc, elem_count * elem_size);
+    return alloc;
 }
 
 void *

--- a/src/mappings.c
+++ b/src/mappings.c
@@ -1,0 +1,96 @@
+#include "mappings.h"
+
+/*******************************************************************************
+ * Forward static declarations
+ ******************************************************************************/
+
+static int
+mappings_compare(const void *, const void *);
+static void
+mappings_clean_one(void *);
+
+/*******************************************************************************
+ * Helper functions
+ ******************************************************************************/
+
+static int
+mappings_compare(const void *arg, const void *item)
+{
+    const struct CompMapping *arg_entry = (const struct CompMapping *) arg;
+    const mapping_entry *item_entry = (const mapping_entry *) item;
+    if (item_entry->map_ref->id == arg_entry->id
+        && item_entry->map_ref->comp == arg_entry->comp)
+    {
+        return 0;
+    }
+    return 1;
+}
+
+static void
+mappings_clean_one(void *entry)
+{
+    free(entry);
+}
+
+/*******************************************************************************
+ * Main functions
+ ******************************************************************************/
+
+mappings_list *
+mappings_init(void)
+{
+    mappings_list *new_list = malloc(sizeof(mappings_list));
+    tommy_hashtable_init(new_list, MAPPINGS_MAX_SZ);
+    return new_list;
+}
+
+void
+mappings_clean(mappings_list *list)
+{
+    tommy_hashtable_done(list);
+    free(list);
+}
+
+void
+mappings_clean_deep(mappings_list *list)
+{
+    tommy_hashtable_foreach(list, mappings_clean_one);
+    mappings_clean(list);
+}
+
+void
+mappings_insert(mapping_entry *to_insert, mappings_list *list)
+{
+    tommy_hashtable_insert(list, &to_insert->node, to_insert,
+        mapping_hash(to_insert->map_ref->comp->id));
+}
+
+struct CompMapping *
+mappings_search_free(struct Compartment *to_search, mappings_list *list)
+{
+    tommy_hashtable_node *search_bucket
+        = tommy_hashtable_bucket(list, mapping_hash(to_search->id));
+    while (search_bucket)
+    {
+        struct CompMapping *cm
+            = ((mapping_entry *) search_bucket->data)->map_ref;
+        if (cm->comp == to_search && !cm->in_use)
+        {
+            return cm;
+        }
+        search_bucket = search_bucket->next;
+    }
+    return NULL;
+}
+
+void
+mappings_delete(struct CompMapping *to_delete, mappings_list *list)
+{
+    if (tommy_hashtable_remove(list, mappings_compare, to_delete,
+            mapping_hash(to_delete->comp->id))
+        == 0)
+    {
+        errx(1, "Unable to find mapping id %zu (for comp %zu) to remove!",
+            to_delete->id, to_delete->comp->id);
+    }
+}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,23 +1,24 @@
 set(BIN_INCLUDE_DIRS ${INCLUDE_DIR} ${TOML_INCLUDE_DIR} ${TOMMYDS_DIR})
+set(BIN_LINK_LIBS chcomp compbench)
 
 # Manager executables
 add_executable(manager_call
     ${TEST_DIR}/manager_caller.c
     )
 target_include_directories(manager_call PUBLIC ${BIN_INCLUDE_DIRS})
-target_link_libraries(manager_call PUBLIC chcomp)
+target_link_libraries(manager_call PUBLIC ${BIN_LINK_LIBS})
 
 add_executable(manager_call_multi
     ${TEST_DIR}/manager_caller_multiple.c
     )
 target_include_directories(manager_call_multi PUBLIC ${BIN_INCLUDE_DIRS})
-target_link_libraries(manager_call_multi PUBLIC chcomp)
+target_link_libraries(manager_call_multi PUBLIC ${BIN_LINK_LIBS})
 
 add_executable(manager_args
     ${TEST_DIR}/manager_arg_passer.c
     )
 target_include_directories(manager_args PUBLIC ${BIN_INCLUDE_DIRS})
-target_link_libraries(manager_args PUBLIC chcomp)
+target_link_libraries(manager_args PUBLIC ${BIN_LINK_LIBS})
 
 # Special tests
 add_executable(comp_harness EXCLUDE_FROM_ALL
@@ -71,7 +72,7 @@ endfunction()
 function(new_func_test test_name)
     add_executable(${test_name}
         ${test_name}.c)
-    target_link_libraries(${test_name} PRIVATE chcomp)
+    target_link_libraries(${test_name} PRIVATE ${BIN_LINK_LIBS})
     target_include_directories(${test_name} PRIVATE
         ${CMAKE_SOURCE_DIR}/src ${BIN_INCLUDE_DIRS})
 endfunction()
@@ -137,6 +138,7 @@ endfunction()
 set(func_binaries
     "test_map"
     "test_map_multi"
+    "test_ddc_overwrite"
 
     #"test_args_near_unmapped"
     #"test_two_comps"
@@ -158,7 +160,6 @@ set(comp_binaries
     "simple_global_var-external"
     "simple_libc"
     "simple_malloc"
-    "simple_malloc_saturate"
     "simple_open_write"
     "simple_fprintf"
     "simple_printf"
@@ -174,6 +175,9 @@ set(comp_binaries
     "tls_check"
     "tls_check-external1"
     "tls_check-external2"
+
+    "simple_malloc_saturate"
+    "fail_random_access"
 
     "lua_simple"
     "lua_script"
@@ -197,7 +201,6 @@ set(tests
     "simple_global_var"
     "simple_libc"
     "simple_malloc"
-    "simple_malloc_saturate"
     "simple_open_write"
     "simple_fprintf"
     "simple_printf"
@@ -210,12 +213,16 @@ set(tests
     "simple_va_args"
     "tls_check"
 
+    "simple_malloc_saturate"
+    "fail_random_access"
+
     "lua_simple"
     "lua_script"
     #"lua_suite_some"
 
     "test_map"
     "test_map_multi"
+    "test_ddc_overwrite"
 
     "args-simple args_simple check_simple 40 2"
     "args-more args_simple check_simple 40 2 2 2" # Check additional arguments are ignored
@@ -224,10 +231,15 @@ set(tests
     "args-long-max args_simple check_llong_max 9223372036854775807"
     "args-long-min args_simple check_llong_min -9223372036854775808"
     "args-ulong-max args_simple check_ullong_max 18446744073709551615"
+
+    "lua_script_hello lua_script do_script_hello"
+    "lua_script_memtest lua_script do_script_memtest"
     )
 
 set(tests_fail
     "simple_malloc_saturate@Memory saturated."
+    "fail_random_access@Caught SIGPROT"
+    "lua_script_memtest@Caught SIGPROT"
 )
 
 # Build targets
@@ -267,6 +279,7 @@ new_dependency(tls_check $<TARGET_FILE:tls_check-external2>)
 new_dependency(test_map $<TARGET_FILE:simple>)
 
 new_dependency(lua_script ${CMAKE_CURRENT_SOURCE_DIR}/hello_world.lua)
+new_dependency(lua_script ${CMAKE_CURRENT_SOURCE_DIR}/memtest.lua)
 
 # Prepare tests
 foreach(test_t IN LISTS tests)

--- a/tests/compartment_harness.c
+++ b/tests/compartment_harness.c
@@ -84,8 +84,10 @@ cheri_offset_set(void *ptr, intptr_t addr)
     return ptr;
 }
 
+#include "../src/benchmarking.c"
 #include "../src/compartment.c"
 #include "../src/manager.c"
+#include "../src/mappings.c"
 
 extern char **environ;
 char **proc_env_ptr;

--- a/tests/fail_random_access.c
+++ b/tests/fail_random_access.c
@@ -1,0 +1,24 @@
+#include <signal.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+static void
+handler(int sig)
+{
+    printf("Caught SIGPROT - %d\n", sig);
+    exit(0);
+}
+
+int
+main(void)
+{
+    signal(SIGPROT, handler);
+    char *ptr;
+    asm("mrs c4, DDC\n\t"
+        "add %[ptr], x4, 0x900000"
+        : [ptr] "=r"(ptr)
+        :
+        : "x4");
+    printf("CHAR %c\n", *ptr);
+    return 0;
+}

--- a/tests/init_test.py
+++ b/tests/init_test.py
@@ -16,7 +16,8 @@ COMP_LIBRARY_PATH = "testing/libs"
 
 LOCAL_LIBS = [
         "./third-party/lua/liblua.so",
-        "./build/src/libcomputils.so"
+        "./build/src/libcomputils.so",
+        "./build/src/libcompbench.so"
         ]
 REMOTE_LIBS = [
         "/lib/libc.so.7",

--- a/tests/lua_script.c
+++ b/tests/lua_script.c
@@ -1,20 +1,17 @@
 #include <assert.h>
+#include <signal.h>
+#include <stdlib.h>
 #include <string.h>
 
 #include <lauxlib.h>
 #include <lua.h>
 #include <lualib.h>
 
-int
-simple_val(void)
+static void
+handler(int sig)
 {
-    return 42;
-}
-
-int
-return_val(int val)
-{
-    return val;
+    printf("Caught SIGPROT - %d\n", sig);
+    exit(0);
 }
 
 int
@@ -30,15 +27,16 @@ do_script_arg(char *script_path)
 }
 
 int
-do_script(void)
+do_script_hello(void)
 {
-    lua_State *L = luaL_newstate();
-    luaL_openlibs(L);
+    return do_script_arg("./hello_world.lua");
+}
 
-    luaL_dofile(L, "./hello_world.lua");
-
-    lua_close(L);
-    return 0;
+int
+do_script_memtest(void)
+{
+    signal(SIGPROT, handler);
+    return do_script_arg("./memtest.lua");
 }
 
 int

--- a/tests/lua_script.comp
+++ b/tests/lua_script.comp
@@ -1,0 +1,12 @@
+[do_script_hello]
+args_type = []
+
+[do_script_memtest]
+args_type = []
+
+[main]
+args_type = []
+
+[compconfig]
+heap=0x800000
+stack=0x80000

--- a/tests/manager_arg_passer.c
+++ b/tests/manager_arg_passer.c
@@ -17,18 +17,21 @@ main(int argc, char **argv)
     manager_ddc = cheri_ddc_get();
     setup_intercepts();
 
-    assert(argc >= 4
-        && "Expect at least three arguments: binary file for compartment, "
-           "entry function for compartment, and at least one argument to pass "
-           "to compartment function.");
+    assert(argc >= 3
+        && "Expect at least two arguments: binary file for compartment, and "
+           "entry function for compartment.");
     char *file = argv[1];
 
     struct Compartment *arg_comp = register_new_comp(file, false);
     struct CompMapping *arg_map = mapping_new(arg_comp);
 
     char *entry_func = argv[2];
-    char **entry_func_args = &argv[3];
-    int comp_result = mapping_exec(arg_map, argv[2], &argv[3]);
+    char **entry_func_args = NULL;
+    if (argc > 3)
+    {
+        entry_func_args = &argv[3];
+    }
+    int comp_result = mapping_exec(arg_map, argv[2], entry_func_args);
     mapping_free(arg_map);
     comp_clean(arg_comp);
     return comp_result;

--- a/tests/manager_caller_multiple.c
+++ b/tests/manager_caller_multiple.c
@@ -1,8 +1,13 @@
+#include "benchmarking.h"
 #include "manager.h"
+#include <stdio.h>
 
 int
 main(int argc, char **argv)
 {
+    size_t b_all = bench_init("all");
+    bench_start(b_all);
+
     const char *count_env_name = "EXECUTE_COUNT";
     const char *count_env_val = getenv(count_env_name);
     const unsigned int comps_count_default = 100;
@@ -28,5 +33,6 @@ main(int argc, char **argv)
     }
     comp_clean(hw_comp);
     assert(!comp_result);
+    bench_end(b_all);
     return comp_result;
 }

--- a/tests/memtest.lua
+++ b/tests/memtest.lua
@@ -1,0 +1,7 @@
+local tab = {}
+
+vals = 1000000
+for i = 1, vals do
+    tab[i] = "menu"
+end
+print(collectgarbage("count"))

--- a/tests/simple_malloc_saturate.c
+++ b/tests/simple_malloc_saturate.c
@@ -2,7 +2,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-const size_t max_heap_size = 0x800000;
+const size_t max_heap_size = 2 * 1024 * 1024;
 const size_t malloc_block_sz = 0x10;
 
 int


### PR DESCRIPTION
Implement a "pseudo" compartment caching feature to evaluate performance in a more ideal implementation. Rather than fully cleaning a mapping for a compartment, we emulate keeping around the last copy, which precludes a pair of `mmap` / `munmap`, as well as downsizing the amount of cleanup needed to be done (we only need to reset the stack, the allocated parts of the heap, and the writeable segments). Note that this is not a full implementation, and it likely breaks with multiple compartments as it currently is.

Major changes
* Move `mappings` code in a separate file
* Implement mapping reuse (includes caching a mapping, cleaning the stack and heap allocations, and resetting writeable segments)
* Add a benchmarking implementation; this is done as it is useful to have, and calls to the benchmarking API are not present in the tree, but can be added by users
* Allow only an entry point be specified in `manager_arg_passer`, rather than requiring arguments to be passed to that entry point
* Add some additional tests, including more failing ones (comment out `lua_suite_some`, as it crashes on the CI system)
* Other fixes