### PR TITLE
Fixes and testing infrastructure

### DIFF
--- a/benchmarks/bench-binarytrees.lua
+++ b/benchmarks/bench-binarytrees.lua
@@ -1,0 +1,63 @@
+-- The Computer Language Shootout
+-- http://shootout.alioth.debian.org/
+-- contributed by Mike Pall
+-- modified by Sokolov yura
+
+--collectgarbage("setstepmul", 0) -- sometimes it helps much. For this benchmark ~ 10%
+
+MIN_DEPTH = 4
+MAX_DEPTH = 12
+EXPECT_CKSUM = -10914
+
+local function BottomUpTree(item, depth)
+  if depth > 0 then
+    local i = item + item
+    depth = depth - 1
+    local left, right = BottomUpTree(i-1, depth), BottomUpTree(i, depth)
+    return { item, left, right }
+  else
+    return { item } -- Faster for LuaJIT: return { item, false }
+  end
+end
+
+local function ItemCheck(tree)
+  if #tree == 3 then -- Faster for LuaJIT: if tree[2] then
+    return tree[1] + ItemCheck(tree[2]) - ItemCheck(tree[3])
+  else
+    return tree[1]
+  end
+end
+
+local function inner_iter(mindepth, maxdepth)
+    local check = 0
+
+	do
+	  local stretchdepth = maxdepth + 1
+	  local stretchtree = BottomUpTree(0, stretchdepth)
+	  check = check +ItemCheck(stretchtree)
+	end
+
+	local longlivedtree = BottomUpTree(0, maxdepth)
+
+	for depth=mindepth,maxdepth,2 do
+	  local iterations = 2 ^ (maxdepth - depth + mindepth)
+	  for i=1,iterations do
+	    check = check + ItemCheck(BottomUpTree(1, depth)) +
+		    ItemCheck(BottomUpTree(-1, depth))
+	  end
+	end
+
+	check = check + ItemCheck(longlivedtree)
+
+    if check ~= EXPECT_CKSUM then
+        puts("bad checksum: " .. checksum .. " vs " .. EXPECT_CKSUM)
+        os.exit(1)
+    end
+end
+
+function run_iter(n)
+    local i
+    for i=1,n do
+        inner_iter(MIN_DEPTH, MAX_DEPTH)
+    end
+end

--- a/benchmarks/bench2-binarytrees.lua
+++ b/benchmarks/bench2-binarytrees.lua
@@ -1,0 +1,50 @@
+-- The Computer Language Benchmarks Game
+-- http://benchmarksgame.alioth.debian.org/
+-- contributed by Mike Pall
+
+local function BottomUpTree(item, depth)
+  if depth > 0 then
+    local i = item + item
+    depth = depth - 1
+    local left, right = BottomUpTree(i-1, depth), BottomUpTree(i, depth)
+    return { item, left, right }
+  else
+    return { item }
+  end
+end
+
+local function ItemCheck(tree)
+  if tree[2] then
+    return tree[1] + ItemCheck(tree[2]) - ItemCheck(tree[3])
+  else
+    return tree[1]
+  end
+end
+
+local N = tonumber(arg and arg[1]) or 0
+local mindepth = 4
+local maxdepth = mindepth + 2
+if maxdepth < N then maxdepth = N end
+
+do
+  local stretchdepth = maxdepth + 1
+  local stretchtree = BottomUpTree(0, stretchdepth)
+  io.write(string.format("stretch tree of depth %d\t check: %d\n",
+    stretchdepth, ItemCheck(stretchtree)))
+end
+
+local longlivedtree = BottomUpTree(0, maxdepth)
+
+for depth=mindepth,maxdepth,2 do
+  local iterations = 2 ^ (maxdepth - depth + mindepth)
+  local check = 0
+  for i=1,iterations do
+    check = check + ItemCheck(BottomUpTree(1, depth)) +
+            ItemCheck(BottomUpTree(-1, depth))
+  end
+  io.write(string.format("%d\t trees of depth %d\t check: %d\n",
+    iterations*2, depth, check))
+end
+
+io.write(string.format("long lived tree of depth %d\t check: %d\n",
+  maxdepth, ItemCheck(longlivedtree)))

--- a/benchmarks/bench2-fannkuchredux.lua
+++ b/benchmarks/bench2-fannkuchredux.lua
@@ -1,0 +1,48 @@
+-- The Computer Language Benchmarks Game
+-- http://benchmarksgame.alioth.debian.org/
+-- contributed by Mike Pall
+
+local function fannkuch(n)
+  local p, q, s, sign, maxflips, sum = {}, {}, {}, 1, 0, 0
+  for i=1,n do p[i] = i; q[i] = i; s[i] = i end
+  repeat
+    -- Copy and flip.
+    local q1 = p[1]				-- Cache 1st element.
+    if q1 ~= 1 then
+      for i=2,n do q[i] = p[i] end		-- Work on a copy.
+      local flips = 1
+      repeat
+	local qq = q[q1]
+	if qq == 1 then				-- ... until 1st element is 1.
+	  sum = sum + sign*flips
+	  if flips > maxflips then maxflips = flips end -- New maximum?
+	  break
+	end
+	q[q1] = q1
+	if q1 >= 4 then
+	  local i, j = 2, q1 - 1
+	  repeat q[i], q[j] = q[j], q[i]; i = i + 1; j = j - 1; until i >= j
+	end
+	q1 = qq; flips = flips + 1
+      until false
+    end
+    -- Permute.
+    if sign == 1 then
+      p[2], p[1] = p[1], p[2]; sign = -1	-- Rotate 1<-2.
+    else
+      p[2], p[3] = p[3], p[2]; sign = 1		-- Rotate 1<-2 and 1<-2<-3.
+      for i=3,n do
+	local sx = s[i]
+	if sx ~= 1 then s[i] = sx-1; break end
+	if i == n then return sum, maxflips end	-- Out of permutations.
+	s[i] = i
+	-- Rotate 1<-...<-i+1.
+	local t = p[1]; for j=1,i do p[j] = p[j+1] end; p[i+1] = t
+      end
+    end
+  until false
+end
+
+local n = tonumber(arg and arg[1]) or 7
+local sum, flips = fannkuch(n)
+io.write(sum, "\nPfannkuchen(", n, ") = ", flips, "\n")

--- a/benchmarks/bench2-heapsort.lua
+++ b/benchmarks/bench2-heapsort.lua
@@ -1,0 +1,48 @@
+local random, floor = math.random, math.floor
+floor = math.ifloor or floor
+
+function heapsort(n, ra)
+    local j, i, rra
+    local l = floor(n/2) + 1
+    -- local l = (n//2) + 1
+    local ir = n;
+    while 1 do
+        if l > 1 then
+            l = l - 1
+            rra = ra[l]
+        else
+            rra = ra[ir]
+            ra[ir] = ra[1]
+            ir = ir - 1
+            if (ir == 1) then
+                ra[1] = rra
+                return
+            end
+        end
+        i = l
+        j = l * 2
+        while j <= ir do
+            if (j < ir) and (ra[j] < ra[j+1]) then
+                j = j + 1
+            end
+            if rra < ra[j] then
+                ra[i] = ra[j]
+                i = j
+                j = j + i
+            else
+                j = ir + 1
+            end
+        end
+        ra[i] = rra
+    end
+end
+
+local Num = tonumber((arg and arg[1])) or 4
+for i=1,Num do
+  local N = tonumber((arg and arg[2])) or 10000
+  local a = {}
+  for i=1,N do a[i] = random() end
+  heapsort(N, a)
+  for i=1,N-1 do assert(a[i] <= a[i+1]) end
+end
+

--- a/benchmarks/bench2-nbody.lua
+++ b/benchmarks/bench2-nbody.lua
@@ -1,0 +1,121 @@
+-- The Computer Language Benchmarks Game
+-- http://benchmarksgame.alioth.debian.org/
+-- contributed by Mike Pall
+-- modified by Geoff Leyland
+-- modified by Mario Pernici
+
+sun = {}
+jupiter = {}
+saturn = {}
+uranus = {}
+neptune = {}
+
+local sqrt = math.sqrt
+
+local PI = 3.141592653589793
+local SOLAR_MASS = 4 * PI * PI
+local DAYS_PER_YEAR = 365.24
+sun.x = 0.0
+sun.y = 0.0
+sun.z = 0.0
+sun.vx = 0.0
+sun.vy = 0.0
+sun.vz = 0.0
+sun.mass = SOLAR_MASS
+jupiter.x = 4.84143144246472090e+00
+jupiter.y = -1.16032004402742839e+00
+jupiter.z = -1.03622044471123109e-01
+jupiter.vx = 1.66007664274403694e-03 * DAYS_PER_YEAR
+jupiter.vy = 7.69901118419740425e-03 * DAYS_PER_YEAR
+jupiter.vz = -6.90460016972063023e-05 * DAYS_PER_YEAR
+jupiter.mass = 9.54791938424326609e-04 * SOLAR_MASS
+saturn.x = 8.34336671824457987e+00
+saturn.y = 4.12479856412430479e+00
+saturn.z = -4.03523417114321381e-01
+saturn.vx = -2.76742510726862411e-03 * DAYS_PER_YEAR
+saturn.vy = 4.99852801234917238e-03 * DAYS_PER_YEAR
+saturn.vz = 2.30417297573763929e-05 * DAYS_PER_YEAR
+saturn.mass = 2.85885980666130812e-04 * SOLAR_MASS
+uranus.x = 1.28943695621391310e+01
+uranus.y = -1.51111514016986312e+01
+uranus.z = -2.23307578892655734e-01
+uranus.vx = 2.96460137564761618e-03 * DAYS_PER_YEAR
+uranus.vy = 2.37847173959480950e-03 * DAYS_PER_YEAR
+uranus.vz = -2.96589568540237556e-05 * DAYS_PER_YEAR
+uranus.mass = 4.36624404335156298e-05 * SOLAR_MASS
+neptune.x = 1.53796971148509165e+01
+neptune.y = -2.59193146099879641e+01
+neptune.z = 1.79258772950371181e-01
+neptune.vx = 2.68067772490389322e-03 * DAYS_PER_YEAR
+neptune.vy = 1.62824170038242295e-03 * DAYS_PER_YEAR
+neptune.vz = -9.51592254519715870e-05 * DAYS_PER_YEAR
+neptune.mass = 5.15138902046611451e-05 * SOLAR_MASS
+
+local bodies = {sun,jupiter,saturn,uranus,neptune}
+
+local function advance(bodies, nbody, dt)
+  for i=1,nbody do
+    local bi = bodies[i]
+    local bix, biy, biz, bimass = bi.x, bi.y, bi.z, bi.mass
+    local bivx, bivy, bivz = bi.vx, bi.vy, bi.vz
+    for j=i+1,nbody do
+      local bj = bodies[j]
+      local dx, dy, dz = bix-bj.x, biy-bj.y, biz-bj.z
+      local dist2 = dx*dx + dy*dy + dz*dz
+      local mag = sqrt(dist2)
+      mag = dt / (mag * dist2)
+      local bm = bj.mass*mag
+      bivx = bivx - (dx * bm)
+      bivy = bivy - (dy * bm)
+      bivz = bivz - (dz * bm)
+      bm = bimass*mag
+      bj.vx = bj.vx + (dx * bm)
+      bj.vy = bj.vy + (dy * bm)
+      bj.vz = bj.vz + (dz * bm)
+    end
+    bi.vx = bivx
+    bi.vy = bivy
+    bi.vz = bivz
+    bi.x = bix + dt * bivx
+    bi.y = biy + dt * bivy
+    bi.z = biz + dt * bivz
+  end
+end
+
+local function energy(bodies, nbody)
+  local e = 0
+  for i=1,nbody do
+    local bi = bodies[i]
+    local vx, vy, vz, bim = bi.vx, bi.vy, bi.vz, bi.mass
+    e = e + (0.5 * bim * (vx*vx + vy*vy + vz*vz))
+    for j=i+1,nbody do
+      local bj = bodies[j]
+      local dx, dy, dz = bi.x-bj.x, bi.y-bj.y, bi.z-bj.z
+      local distance = sqrt(dx*dx + dy*dy + dz*dz)
+      e = e - ((bim * bj.mass) / distance)
+    end
+  end
+  return e
+end
+
+local function offsetMomentum(b, nbody)
+  local px, py, pz = 0, 0, 0
+  for i=1,nbody do
+    local bi = b[i]
+    local bim = bi.mass
+    px = px + (bi.vx * bim)
+    py = py + (bi.vy * bim)
+    pz = pz + (bi.vz * bim)
+  end
+  b[1].vx = -px / SOLAR_MASS
+  b[1].vy = -py / SOLAR_MASS
+  b[1].vz = -pz / SOLAR_MASS
+end
+
+local N = tonumber(arg and arg[1]) or 1000
+local nbody = #bodies
+
+offsetMomentum(bodies, nbody)
+io.write( string.format("%0.9f",energy(bodies, nbody)), "\n")
+for i=1,N do advance(bodies, nbody, 0.01) end
+io.write( string.format("%0.9f",energy(bodies, nbody)), "\n")

--- a/benchmarks/bench2-sieve.lua
+++ b/benchmarks/bench2-sieve.lua
@@ -1,0 +1,33 @@
+-- $Id: sieve.lua,v 1.9 2001/05/06 04:37:45 doug Exp $
+-- http://www.bagley.org/~doug/shootout/
+--
+-- Roberto Ierusalimschy pointed out the for loop is much
+-- faster for our purposes here than using a while loop.
+
+local count = 0
+
+function main(num, lim)
+    local flags = {}
+    for num=num,1,-1 do
+	count = 0
+	for i=1,lim do
+          flags[i] = 1
+        end
+	for i=2,lim do
+	    if flags[i] == 1 then
+	        k = 0
+	        for k=i+i, lim, i do
+		    flags[k] = 0
+		end
+	        count = count + 1	
+	    end
+	end
+    end
+end
+
+NUM = tonumber((arg and arg[1])) or 100
+lim = (arg and arg[2]) or 8192 
+print(NUM,lim)
+count = 0
+main(NUM, lim)
+print("Count: ", count)

--- a/benchmarks/big.lua
+++ b/benchmarks/big.lua
@@ -1,0 +1,1 @@
+../third-party/lua/testes/big.lua

--- a/benchmarks/hello_world.lua
+++ b/benchmarks/hello_world.lua
@@ -1,0 +1,1 @@
+../tests/hello_world.lua

--- a/benchmarks/math.lua
+++ b/benchmarks/math.lua
@@ -1,0 +1,1 @@
+../third-party/lua/testes/math.lua

--- a/benchmarks/sources
+++ b/benchmarks/sources
@@ -1,0 +1,4 @@
+The sources for these benchmarks are as follows:
+* `big.lua` and `math.lua` are part of the Lua test suite (https://www.lua.org/home.html)
+* tests pre-pended with `bench` are part of the `softdevteam` `lua_benchmarking` project (https://github.com/softdevteam/lua_benchmarking)
+* tests pre-pended with `bench2` are part of the `Lua-Benchmarks` suite packaged by Gabriel de Quadros Ligneul (https://github.com/gligneul/Lua-Benchmarks)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -2,23 +2,23 @@ set(BIN_INCLUDE_DIRS ${INCLUDE_DIR} ${TOML_INCLUDE_DIR} ${TOMMYDS_DIR})
 set(BIN_LINK_LIBS chcomp compbench)
 
 # Manager executables
-add_executable(manager_call
-    ${TEST_DIR}/manager_caller.c
-    )
-target_include_directories(manager_call PUBLIC ${BIN_INCLUDE_DIRS})
-target_link_libraries(manager_call PUBLIC ${BIN_LINK_LIBS})
+function(new_manager_bin bin_name)
+    add_executable(${bin_name}
+        ${bin_name}.c)
+    target_include_directories(${bin_name} PUBLIC ${BIN_INCLUDE_DIRS})
+    target_link_libraries(${bin_name} PUBLIC ${BIN_LINK_LIBS})
+endfunction()
 
-add_executable(manager_call_multi
-    ${TEST_DIR}/manager_caller_multiple.c
-    )
-target_include_directories(manager_call_multi PUBLIC ${BIN_INCLUDE_DIRS})
-target_link_libraries(manager_call_multi PUBLIC ${BIN_LINK_LIBS})
+set(manager_bins
+    "manager_caller"
+    "manager_caller_multiple"
+    "manager_arg_passer"
+    "manager_arg_passer_multiple"
+)
 
-add_executable(manager_args
-    ${TEST_DIR}/manager_arg_passer.c
-    )
-target_include_directories(manager_args PUBLIC ${BIN_INCLUDE_DIRS})
-target_link_libraries(manager_args PUBLIC ${BIN_LINK_LIBS})
+foreach(bin_t IN LISTS manager_bins)
+    new_manager_bin(${bin_t})
+endforeach()
 
 # Special tests
 add_executable(comp_harness EXCLUDE_FROM_ALL
@@ -99,7 +99,7 @@ function(new_test test_name)
         if(is_comp)
             add_test(NAME ${test_name}
                      COMMAND ${CMAKE_SOURCE_DIR}/tests/run_test.py
-                             manager_call
+                             $<TARGET_FILE:manager_caller>
                              --test-args $<TARGET_FILE_NAME:${test_name}>
                              --dependencies ${deps_var}
                      COMMAND_EXPAND_LISTS)
@@ -118,7 +118,7 @@ function(new_test test_name)
         if(is_comp)
             add_test(NAME ${test_name}
                 COMMAND ${CMAKE_SOURCE_DIR}/tests/run_test.py
-                        manager_args
+                        $<TARGET_FILE:manager_arg_passer>
                         --test-args $<TARGET_FILE_NAME:${test_bin}> ${test_args}
                         --dependencies ${deps_var}
                 COMMAND_EXPAND_LISTS)
@@ -182,6 +182,7 @@ set(comp_binaries
     "lua_simple"
     "lua_script"
     "lua_suite_some"
+    "lua_script_selector"
 
     "args_simple"
     #"test_two_comps-comp1"

--- a/tests/lua_script_selector.c
+++ b/tests/lua_script_selector.c
@@ -1,0 +1,72 @@
+#include <err.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#include <lauxlib.h>
+#include <lua.h>
+#include <lualib.h>
+
+const unsigned int max_path_sz = 256;
+const char *test_dir = "./lua";
+const char *test_names[] = {
+    "bench-binarytrees.lua",
+    "bench2-binarytrees.lua",
+    "bench2-fannkuchredux.lua",
+    "bench2-heapsort.lua",
+    "bench2-nbody.lua",
+    "bench2-sieve.lua",
+    "hello_world.lua",
+    "math.lua",
+    "tracegc.lua",
+};
+
+int
+do_script_id(const unsigned int test_id)
+{
+    char test_path[max_path_sz];
+    snprintf(
+        test_path, sizeof(test_path), "%s/%s", test_dir, test_names[test_id]);
+    if (access(test_path, F_OK) != 0)
+    {
+        errx(1, "Could not find test file `%s` for ID %d!", test_path, test_id);
+    }
+
+    printf("Running test ID %u at `%s`\n", test_id, test_path);
+
+    lua_State *L = luaL_newstate();
+    luaL_openlibs(L);
+    int res = luaL_dofile(L, test_path);
+    lua_close(L);
+
+    if (res != LUA_OK)
+    {
+        errx(1, "Error running test `%s`!", test_path);
+    }
+
+    printf("Done\n");
+
+    return 0;
+}
+
+int
+main(int argc, char **argv)
+{
+    if (argc != 2)
+    {
+        errx(1, "Expected exactly one argument: identifier of test to run!");
+    }
+
+    unsigned int test_id = atoi(argv[1]);
+    const unsigned int test_count = sizeof(test_names) / sizeof(char *);
+    if (test_id >= test_count)
+    {
+        errx(1, "Was given ID %d, but only %u tests available!", test_id,
+            test_count);
+    }
+
+    do_script_id(test_id);
+
+    return 0;
+}

--- a/tests/lua_script_selector.comp
+++ b/tests/lua_script_selector.comp
@@ -1,0 +1,2 @@
+[do_script_id]
+args_type = ["int"]

--- a/tests/manager_arg_passer_multiple.c
+++ b/tests/manager_arg_passer_multiple.c
@@ -1,0 +1,52 @@
+#include <stdlib.h>
+
+#include "manager.h"
+
+/* Test wrapper for compartments with arguments.
+ *
+ * Takes at least two arguments: one argument for the compartment binary name,
+ * and one argument minimum to be passed to the compartment itself.
+ * TODO currently hard coding the entry points and which entry point to call,
+ * but plan to move this to some configuration file in the near future
+ */
+
+int
+main(int argc, char **argv)
+{
+    const char *count_env_name = "EXECUTE_COUNT";
+    const char *count_env_val = getenv(count_env_name);
+    const unsigned int comps_count_default = 100;
+    unsigned int comps_count
+        = count_env_val ? atoi(count_env_val) : comps_count_default;
+
+    // Initial setup
+    manager_ddc = cheri_ddc_get();
+    setup_intercepts();
+
+    assert(argc >= 3
+        && "Expect at least two arguments: binary file for compartment, and "
+           "entry function for compartment.");
+    char *file = argv[1];
+
+    struct Compartment *arg_comp = register_new_comp(file, false);
+    struct CompMapping *arg_map;
+    char *entry_func = argv[2];
+    char **entry_func_args = NULL;
+    if (argc > 3)
+    {
+        entry_func_args = &argv[3];
+    }
+    int comp_result = 0;
+
+    for (size_t i = 0; i < comps_count; ++i)
+    {
+        arg_map = mapping_new(arg_comp);
+        comp_result
+            = mapping_exec(arg_map, argv[2], entry_func_args) || comp_result;
+        mapping_free(arg_map);
+    }
+    comp_clean(arg_comp);
+    assert(!comp_result);
+
+    return comp_result;
+}

--- a/tests/manager_caller_multiple.c
+++ b/tests/manager_caller_multiple.c
@@ -1,13 +1,9 @@
-#include "benchmarking.h"
 #include "manager.h"
 #include <stdio.h>
 
 int
 main(int argc, char **argv)
 {
-    size_t b_all = bench_init("all");
-    bench_start(b_all);
-
     const char *count_env_name = "EXECUTE_COUNT";
     const char *count_env_val = getenv(count_env_name);
     const unsigned int comps_count_default = 100;
@@ -33,6 +29,5 @@ main(int argc, char **argv)
     }
     comp_clean(hw_comp);
     assert(!comp_result);
-    bench_end(b_all);
     return comp_result;
 }


### PR DESCRIPTION
* Added `manager_arg_passer_multi`, a wrapper to execute a compartment which takes arguments multiple times (basically a combination of `manager_arg_passer` and `manager_comp_multiple`)
* Added `lua_script_selector`, with a number of hardcoded `lua` script location, selectable by an integer id (we can't pass pointers to containers), to run different benchmarks
* Fix the order in which we zero out memory; we must zero the segments after clearing the heap allocations, else we float the allocation header pointer

Minor changes:
* Simplify manager wrapper CMake script
* Rename for consistency